### PR TITLE
Remove dependency on IControlCenter

### DIFF
--- a/CADability.Forms/CadFrame.cs
+++ b/CADability.Forms/CadFrame.cs
@@ -52,6 +52,16 @@ namespace CADability.Forms
         {
             this.commandHandler = commandHandler;
         }
+        /// <summary>
+        /// Constructor without form dependency.
+        /// </summary>        
+        /// <param name="cadCanvas"></param>
+        /// <param name="commandHandler"></param>
+        public CadFrame(CadCanvas cadCanvas, ICommandHandler commandHandler)
+            : base(cadCanvas)
+        {
+            this.commandHandler = commandHandler;
+        }
 
         #region FrameImpl override
 

--- a/CADability/Frame.cs
+++ b/CADability/Frame.cs
@@ -311,6 +311,10 @@ namespace CADability
             Project = pr;
             ActiveView = modelView;
         }
+        public FrameImpl(ICanvas canvas) : this()
+        {
+            this.canvas = canvas;
+        }
 
         /// <summary>
         /// Returns the <see cref="ICommandHandler">CommandHandler</see> of this frame. All menu and toolbar commands
@@ -848,12 +852,12 @@ namespace CADability
 
         public void ShowPropertyDisplay(string Name)
         {
-            ControlCenter.ShowPropertyPage(Name);
+            ControlCenter?.ShowPropertyPage(Name);
         }
 
         IPropertyPage IFrame.GetPropertyDisplay(string Name)
         {
-            return ControlCenter.GetPropertyPage(Name);
+            return ControlCenter?.GetPropertyPage(Name);
         }
 
         #region handling menu commands


### PR DESCRIPTION
Remove dependency on IControlCenter.
We don't use the IControlCenter at all and need to remove the dependency on it.