### PR TITLE
Update CADability project to use $(VsInstallRoot) for DebuggerVisualizers

### DIFF
--- a/CADability/CADability.csproj
+++ b/CADability/CADability.csproj
@@ -55,7 +55,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.DebuggerVisualizers.dll</HintPath>
+      <HintPath>$(VsInstallRoot)\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.DebuggerVisualizers.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
The path of Microsoft.VisualStudio.DebuggerVisualizers.dll depends on the path of the project and Visual Studio.