### PR TITLE
Fix hotspot label

### DIFF
--- a/CADability/AngleProperty.cs
+++ b/CADability/AngleProperty.cs
@@ -48,6 +48,10 @@ namespace CADability.UserInterface
         {
             return angleProperty.LabelText;
         }
+        public string ResourceId
+        {
+            get { return angleProperty.ResourceId; }
+        }
         MenuWithHandler[] IHotSpot.ContextMenu
         {
             get

--- a/CADability/AngleProperty.cs
+++ b/CADability/AngleProperty.cs
@@ -46,7 +46,7 @@ namespace CADability.UserInterface
         }
         string IHotSpot.GetInfoText(CADability.UserInterface.InfoLevelMode Level)
         {
-            return angleProperty.LabelText;
+            return angleProperty.Label;
         }
         public string ResourceId
         {

--- a/CADability/DoubleProperty.cs
+++ b/CADability/DoubleProperty.cs
@@ -54,6 +54,10 @@ namespace CADability.UserInterface
         {
             return doubleProperty.LabelText;
         }
+        public string ResourceId
+        {
+            get { return doubleProperty.ResourceId; }
+        }
         public MenuWithHandler[] ContextMenu
         {
             get

--- a/CADability/GeoPointProperty.cs
+++ b/CADability/GeoPointProperty.cs
@@ -61,6 +61,10 @@ namespace CADability.UserInterface
         {
             return null;
         }
+        public string ResourceId
+        {
+            get { return null; }
+        }
 
         MenuWithHandler[] IHotSpot.ContextMenu
         {

--- a/CADability/GeoVectorProperty.cs
+++ b/CADability/GeoVectorProperty.cs
@@ -43,7 +43,7 @@ namespace CADability.UserInterface
         }
         public string GetInfoText(CADability.UserInterface.InfoLevelMode Level)
         {
-            return geoVectorProperty.LabelText;
+            return geoVectorProperty.Label;
         }
         public string ResourceId
         {

--- a/CADability/GeoVectorProperty.cs
+++ b/CADability/GeoVectorProperty.cs
@@ -45,6 +45,10 @@ namespace CADability.UserInterface
         {
             return geoVectorProperty.LabelText;
         }
+        public string ResourceId
+        {
+            get { return geoVectorProperty.ResourceId; }
+        }
         MenuWithHandler[] IHotSpot.ContextMenu
         {
             get

--- a/CADability/IDisplayHotSpots.cs
+++ b/CADability/IDisplayHotSpots.cs
@@ -53,6 +53,10 @@ namespace CADability
         /// <param name="Level">Requested info level (simple info or detailed info)</param>
         /// <returns>The info string</returns>
         string GetInfoText(CADability.UserInterface.InfoLevelMode Level);
+        /// <summary>
+        /// Get the ResourceId of the Hotspot
+        /// </summary>
+        string ResourceId { get; }
         MenuWithHandler[] ContextMenu { get; }
         // hier könnte man noch ein Paint dazunehmen, um den Hotspots die
         // Möglichkeit zu geben, sich selbst gemäß ihrer Bedeutung darzustellen

--- a/CADability/LengthProperty.cs
+++ b/CADability/LengthProperty.cs
@@ -52,6 +52,10 @@ namespace CADability.UserInterface
         {
             return lengthProperty.Label;
         }
+        public string ResourceId
+        {
+            get { return lengthProperty.ResourceId; }
+        }
         MenuWithHandler[] IHotSpot.ContextMenu
         {
             get

--- a/CADability/ShowPropertyHotSpot.cs
+++ b/CADability/ShowPropertyHotSpot.cs
@@ -59,6 +59,10 @@ namespace CADability.UserInterface
         {
             return showProperty.Label;
         }
+        public string ResourceId
+        {
+            get { return showProperty.ResourceId; }
+        }
         MenuWithHandler[] IHotSpot.ContextMenu
         {
             get


### PR DESCRIPTION
Fix GetInfoText in AngleProperty and GeoVectorProperty to use Label and not LabelText.
Otherwise the tooltip for these Hotspots will not be displayed.