### PR TITLE
Fix path to program files folder on x64 machines with a x86 process.

### DIFF
--- a/CADability/Project.cs
+++ b/CADability/Project.cs
@@ -1669,18 +1669,30 @@ namespace CADability
                     if (String.IsNullOrEmpty(converter))
                     {
                         isInSetting = false;
-                        //converter = @"C:\Program Files\ODA\ODAFileConverter_title 21.3.0\ODAFileConverter.exe";
-                        var pf86 = Environment.GetEnvironmentVariable("ProgramW6432") + System.IO.Path.DirectorySeparatorChar + "ODA";
-                        // string programfiles = System.Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) + System.IO.Path.DirectorySeparatorChar + "ODA";
-                        string programfiles = System.Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles) + System.IO.Path.DirectorySeparatorChar + "ODA";
-                        string[] oda = Directory.GetFiles(programfiles, "odafileconverter.exe", SearchOption.AllDirectories);
+
+                        string programFilesPath = string.Empty;
+
+                        if (Environment.Is64BitOperatingSystem && !Environment.Is64BitProcess)
+                        {
+                            programFilesPath = Environment.GetEnvironmentVariable("ProgramW6432");
+                        }
+                        else
+                        {
+                            programFilesPath = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                        }
+
+                        //converter = @"C:\Program Files\ODA\ODAFileConverter_title 21.3.0\ODAFileConverter.exe";                        
+                        string odaFolder = System.IO.Path.Combine(programFilesPath, "ODA");
+
+                        string[] oda = Directory.GetFiles(odaFolder, "odafileconverter.exe", SearchOption.AllDirectories);
+
                         for (int i = 0; i < oda.Length; i++)
                         {
                             string fn = System.IO.Path.GetDirectoryName(oda[i]);
                             if (!string.IsNullOrEmpty(converter))
                             {
                                 string fnc = System.IO.Path.GetDirectoryName(converter);
-                                if (string.Compare(fnc, fn, true) > 0) converter = oda[i];
+                                if (string.Compare(fnc, fn, true) < 0) converter = oda[i];
                             }
                             else
                             {


### PR DESCRIPTION
The path to program files folder was wrong if a 32bit process was running on a 64bit machine.

Also `string.Compare(fnc, fn, true) > 0` seems to be wrong. 
It would choose the smallest (oldest) version. Not the newest one.

Is it a good solution to save the path of the converter to DwgDxfConverter?

1. This way we would be stuck with a specific version.
2. I guess this function would also fail if an update to a new version of the ODA Converter was performed and the old version was removed.