### PR TITLE
Update projects to use MathNet Signed

### DIFF
--- a/CADability.Forms/CADability.Forms.csproj
+++ b/CADability.Forms/CADability.Forms.csproj
@@ -69,8 +69,8 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MathNet.Numerics, Version=4.15.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MathNet.Numerics.4.15.0\lib\net461\MathNet.Numerics.dll</HintPath>
+    <Reference Include="MathNet.Numerics, Version=4.15.0.0, Culture=neutral, PublicKeyToken=cd8b63ad3d691a37, processorArchitecture=MSIL">
+      <HintPath>..\packages\MathNet.Numerics.Signed.4.15.0\lib\net461\MathNet.Numerics.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/CADability.Forms/packages.config
+++ b/CADability.Forms/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="docfx.console" version="2.56.4" targetFramework="net462" developmentDependency="true" />
-  <package id="MathNet.Numerics" version="4.15.0" targetFramework="net462" />
+  <package id="MathNet.Numerics.Signed" version="4.15.0" targetFramework="net462" />
   <package id="System.Drawing.Common" version="4.7.0" targetFramework="net462" />
 </packages>

--- a/CADability/CADability.csproj
+++ b/CADability/CADability.csproj
@@ -81,7 +81,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
+    <PackageReference Include="MathNet.Numerics.Signed" Version="4.15.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
It's necessary to use MathNet Signed to be able to sign the assembly.

Otherwise this error will be shown:
"Referenced assembly 'MathNet.Numerics, Version=4.15.0.0, Culture=neutral, PublicKeyToken=null' does not have a strong name"
