### PR TITLE
Fix typo in cursor name #2

### DIFF
--- a/CADability/MoveObjects.cs
+++ b/CADability/MoveObjects.cs
@@ -123,7 +123,7 @@ namespace CADability.Actions
             feedBackLine = Line.Construct();
             Color backColor = base.Frame.GetColorSetting("Colors.Feedback", Color.DarkGray);
             feedBackLine.ColorDef = new ColorDef("", backColor);
-            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "Move.cur");
+            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "Move");
 
 
             vec = new GeoVectorInput("MoveObjects.Vector");

--- a/CADability/RotateObjects.cs
+++ b/CADability/RotateObjects.cs
@@ -253,7 +253,7 @@ namespace CADability.Actions
             Color backColor = base.Frame.GetColorSetting("Colors.Feedback", Color.DarkGray);
             feedBackEllipse.ColorDef = new ColorDef("", backColor);
             base.FeedBack.Add(feedBackEllipse);
-            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "RotateSmall.cur");
+            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "RotateSmall");
 
             //--> diese Inputs werden gebraucht
             GeoPointInput refPointInput = new GeoPointInput("Objects.RefPoint");

--- a/CADability/ScaleObjects.cs
+++ b/CADability/ScaleObjects.cs
@@ -371,7 +371,7 @@ namespace CADability.Actions
             feedBackLine = Line.Construct();
             Color backColor = base.Frame.GetColorSetting("Colors.Feedback", Color.DarkGray);
             feedBackLine.ColorDef = new ColorDef("", backColor);
-            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "Size.cur");
+            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "Size");
             clickandPress = false;
 
             GeoPointInput fixPoint = new GeoPointInput("Objects.FixPoint", base.BasePoint);

--- a/CADability/SnapObjects.cs
+++ b/CADability/SnapObjects.cs
@@ -203,7 +203,7 @@ namespace CADability.Actions
             Color backColor = base.Frame.GetColorSetting("Colors.Feedback", Color.DarkGray);
             feedBackLine.ColorDef = new ColorDef("", backColor);
             base.FeedBack.Add(feedBackLine);
-            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "ScaleSnap.cur");
+            base.SetCursor(SnapPointFinder.DidSnapModes.DidNotSnap, "ScaleSnap");
             // Punktepaare
             srcP1 = new GeoPointInput("SnapObjects.Source1");
             srcP1.SetGeoPointEvent += new CADability.Actions.ConstructAction.GeoPointInput.SetGeoPointDelegate(SetSourcePoint1);


### PR DESCRIPTION
The cursor name contained the extension (.cur).