### PR TITLE
Remove unused .DontRecalcTriangulation

### DIFF
--- a/CADability.Forms/PaintToGDI.cs
+++ b/CADability.Forms/PaintToGDI.cs
@@ -326,17 +326,6 @@ namespace CADability.Forms
             get { return false; }
         }
 
-        bool IPaintTo3D.DontRecalcTriangulation
-        {
-            get
-            {
-                return false;
-            }
-            set
-            {
-                throw new Exception("The method or operation is not implemented.");
-            }
-        }
         PaintCapabilities IPaintTo3D.Capabilities
         {
             get
@@ -527,7 +516,7 @@ namespace CADability.Forms
             string textString, FontStyle fontStyle, CADability.GeoObject.Text.AlignMode alignment,
             CADability.GeoObject.Text.LineAlignMode lineAlignment)
         {
-            // graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.SingleBitPerPixel; 
+            // graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.SingleBitPerPixel;
             // das wäre für Kastenholz, beim selektieren von kleinen Schriften keine Ränder
             bool makeLine = false;
             PointF[] pnt = new PointF[3];
@@ -601,7 +590,7 @@ namespace CADability.Forms
                                 //    break;
                                 //case Text.AlignMode.Baseline: // hier müsste man den Punkt verschieben
                                 //    sf.LineAlignment = StringAlignment.Near;
-                                //    //loc.Y = 
+                                //    //loc.Y =
                                 //    break;
                                 //case Text.AlignMode.Center:
                                 //    sf.LineAlignment = StringAlignment.Center;
@@ -655,7 +644,7 @@ namespace CADability.Forms
         {
             DisplayList dl = paintThisList as DisplayList;
             graphics.DrawImageUnscaled(dl.bitmap, 0, 0);
-            // dl.bitmap.Save("tmp.jpg", System.Drawing.Imaging.ImageFormat.Jpeg); 
+            // dl.bitmap.Save("tmp.jpg", System.Drawing.Imaging.ImageFormat.Jpeg);
         }
 
         void IPaintTo3D.Nurbs(GeoPoint[] poles, double[] weights, double[] knots, int degree)
@@ -665,7 +654,7 @@ namespace CADability.Forms
 
         void IPaintTo3D.Line2D(int sx, int sy, int ex, int ey)
         {
-            using (new Transform(graphics, new Matrix())) // Identität 
+            using (new Transform(graphics, new Matrix())) // Identität
             {
                 try
                 {
@@ -682,7 +671,7 @@ namespace CADability.Forms
 
         void IPaintTo3D.Line2D(PointF p1, PointF p2)
         {
-            using (new Transform(graphics, new Matrix())) // Identität 
+            using (new Transform(graphics, new Matrix())) // Identität
             {
                 try
                 {
@@ -699,7 +688,7 @@ namespace CADability.Forms
 
         void IPaintTo3D.FillRect2D(PointF p1, PointF p2)
         {
-            using (new Transform(graphics, new Matrix())) // Identität 
+            using (new Transform(graphics, new Matrix())) // Identität
             {
                 try
                 {
@@ -940,7 +929,7 @@ namespace CADability.Forms
         }
         //void IPaintTo3D.Arc(GeoPoint center, GeoVector majorAxis, GeoVector minorAxis, double startParameter, double sweepParameter)
         //{   // Das Problem ist, dass GDI nur achsenorientierte Ellipsen zeichnen kann.
-        //    // Wir müssen die Drehung hier rausrechnen, denn die zu verwendende Matrix 
+        //    // Wir müssen die Drehung hier rausrechnen, denn die zu verwendende Matrix
         //    // darf nicht skalieren wegen der Strichstärke und der Strichlierung
 
         //    GeoVector normal = majorAxis ^ minorAxis; // normale der Ebene des Bogens
@@ -1087,7 +1076,7 @@ namespace CADability.Forms
         //    //    }
         //    //}
         //    //catch (ApplicationException)
-        //    //{ // 
+        //    //{ //
         //    //}
         //}
         IPaintTo3DList IPaintTo3D.MakeList(System.Collections.Generic.List<IPaintTo3DList> sublists)
@@ -1167,7 +1156,7 @@ namespace CADability.Forms
 
         void IPaintTo3D.PreparePointSymbol(PointSymbol pointSymbol)
         {
-            
+
         }
         #endregion
     }

--- a/CADability.Forms/PaintToOpenGL.cs
+++ b/CADability.Forms/PaintToOpenGL.cs
@@ -39,7 +39,6 @@ namespace CADability.Forms
         bool selectMode;
         bool delayText;
         bool delayAll;
-        bool dontRecalcTriangulation;
         bool isBitmap; // Bitmaps verhalten sich komisch in Bezug auf DisplayListen (zumindest auf meinem Rechner, G.)
         double lineWidthFactor;
         float lineWidthMin, lineWidthMax;
@@ -174,7 +173,7 @@ namespace CADability.Forms
                 res.deviceContext = deviceContext;
                 // die Standardzeichen generieren (fehlt noch bold, italic)
                 // um den text selbst zu generieren könnte man wie folgt vorgehen:
-                // System.Drawing.Drawing2D.GraphicsPath, System.Drawing.Drawing2D.GraphicsPath. Flatten, 
+                // System.Drawing.Drawing2D.GraphicsPath, System.Drawing.Drawing2D.GraphicsPath. Flatten,
                 // System.Drawing.Drawing2D.PathPointType
                 // eine Nurbs Ebene generieren und die polygone als Trimmkurve nehmen
 
@@ -544,17 +543,6 @@ namespace CADability.Forms
         {
             get { return true; }
         }
-        bool IPaintTo3D.DontRecalcTriangulation
-        {
-            get
-            {
-                return dontRecalcTriangulation;
-            }
-            set
-            {
-                dontRecalcTriangulation = value;
-            }
-        }
         PaintCapabilities IPaintTo3D.Capabilities
         {
             get
@@ -617,7 +605,7 @@ namespace CADability.Forms
                 {
                     // Wgl.wglGetCurrentContext();
                     // bool ok = Wgl.wglMakeCurrent(deviceContext, renderContext);
-                    // if (ok) 
+                    // if (ok)
                     bool ok = false;
                     // xxx ok = Wgl.wglDeleteContext(renderContext);
                     // man darf ihn hier nicht löschen, da er noch als Context für die SharedLists gebraucht wird
@@ -669,7 +657,7 @@ namespace CADability.Forms
             //        w.WriteLine(str);
             //    }
             //}
-            // Ende Hilgers Debug 
+            // Ende Hilgers Debug
             if (error == Gl.GL_OUT_OF_MEMORY)
             {
                 currentList = null; // die bleibt sonst offen
@@ -1172,9 +1160,9 @@ namespace CADability.Forms
                 // ich finde keine Möglichkeit die Position auf z.B. die Mitte oder einen beliebigen Punkt des
                 // Bitmaps zu setzen. Außer: In Notes zu glBitmap steht:
                 // Notes
-                // To set a valid raster position outside the viewport, first set a valid raster position inside the viewport, 
-                // then call glBitmap with NULL as the bitmap parameter and with xmove and ymove set to the offsets of the 
-                // new raster position. This technique is useful when panning an image around the viewport. 
+                // To set a valid raster position outside the viewport, first set a valid raster position inside the viewport,
+                // then call glBitmap with NULL as the bitmap parameter and with xmove and ymove set to the offsets of the
+                // new raster position. This technique is useful when panning an image around the viewport.
                 Gl.glBitmap(0, 0, 0, 0, -xoffset, -yoffset, null);
                 Gl.glPixelStorei(Gl.GL_PACK_SWAP_BYTES, 0);
                 Gl.glPixelStorei(Gl.GL_PACK_LSB_FIRST, 0);
@@ -1619,7 +1607,7 @@ namespace CADability.Forms
         private void PaintListWithOffset(IPaintTo3DList paintThisList, int offsetX, int offsetY)
         {
             Gl.glMatrixMode(Gl.GL_PROJECTION);
-            // leider macht die glTranslated funktion ein Matrix in der zuerst die verschiebung und dann die 
+            // leider macht die glTranslated funktion ein Matrix in der zuerst die verschiebung und dann die
             // alte projektion stattfinden
             double[] current = new double[16];
             Gl.glGetDoublev(Gl.GL_PROJECTION_MATRIX, current);
@@ -1659,7 +1647,7 @@ namespace CADability.Forms
                 Gl.glLoadIdentity();
                 Gl.glTranslated(-2 * precision * projectionDirection.x, -2 * precision * projectionDirection.y, -2 * precision * projectionDirection.z);
 
-                //Gl.glEnable(Gl.GL_TEXTURE_2D); 
+                //Gl.glEnable(Gl.GL_TEXTURE_2D);
                 if (wobbleRadius == -1) Gl.glClear(Gl.GL_DEPTH_BUFFER_BIT); // Select findet über den Objekten statt, alte ZBuffer Inhalte werden gelöscht
                 Gl.glEnable(Gl.GL_DEPTH_TEST);
 
@@ -1738,7 +1726,7 @@ namespace CADability.Forms
         //    // Objekt selbst durch den Stencil Buffer nicht überzeichnet werden kann
         //    Gl.glDisable(Gl.GL_DEPTH_TEST);
         //    Gl.glClearStencil(0x0);
-        //    Gl.glEnable(Gl.GL_STENCIL_TEST); 
+        //    Gl.glEnable(Gl.GL_STENCIL_TEST);
         //    Gl.glClear(Gl.GL_STENCIL_BUFFER_BIT);
         //    Gl.glStencilFunc(Gl.GL_ALWAYS, 0x1, 0x1);
         //    Gl.glStencilOp(Gl.GL_REPLACE, Gl.GL_REPLACE, Gl.GL_REPLACE);
@@ -2160,12 +2148,12 @@ namespace CADability.Forms
                 if (isDeleted)
                     return;
 
-                isDeleted = true;                
+                isDeleted = true;
             }
             openLists.Remove(ListNumber);
 #if DEBUG
             //System.Diagnostics.Trace.WriteLine("Direct Deleting OpenGl List Nr.: " + ListNumber.ToString());
-#endif            
+#endif
             Gl.glDeleteLists(ListNumber, 1);
         }
         #region IPaintTo3DList Members

--- a/CADability/AnimatedView.cs
+++ b/CADability/AnimatedView.cs
@@ -27,11 +27,11 @@ namespace CADability
      * GeoObjekte können einen Actuator (IDrive) haben. Das Modell hat eine Liste aller Drives.
      * Die Drives sind u.U. voneinander abhängig. Daraus ergibt sich ein Baum.
      * Vor der Simulation wird zu jedem Drive eine Displaylist erzeugt. Während des
-     * Ablaufs wird für jeden Drive die ModOp bestimmt, die sich aus den Abhängigkeiten 
+     * Ablaufs wird für jeden Drive die ModOp bestimmt, die sich aus den Abhängigkeiten
      * und den einzelnen ModOps ergibt.
      * Die DisplayListen werden mit den ModOps versehen dargestellt. (Kanten/Flächen unterscheidung?)
      * Einige Objekte werden jeweils gesondert ausgegeben (wg. Farbänderung)
-     * 
+     *
      * Das Modell enthält eine Liste aller Drives.
      * Die Ansicht enthält einen Ablaufplan Schedule
     */
@@ -308,7 +308,7 @@ namespace CADability
         /// </summary>
         public event NextStepDelegate NextStepEvent;
         /// <summary>
-        /// Delegate for the <see cref="GetTimeEvent"/>. If not handeled the time is 
+        /// Delegate for the <see cref="GetTimeEvent"/>. If not handeled the time is
         /// determined by the internal clock.
         /// </summary>
         /// <param name="sender">The calling AnimtedView</param>
@@ -351,10 +351,10 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Starts the realtime animation. <paramref name="speed"/> provides a time factor, 
-        /// 1.0 is real time. The method returns immediately. There may bee zooming and scrolling 
-        /// during the animation. The animation may be stopped at any time and stops automatically 
-        /// when endTime is reached. Each discrete frame that is displayed fires the 
+        /// Starts the realtime animation. <paramref name="speed"/> provides a time factor,
+        /// 1.0 is real time. The method returns immediately. There may bee zooming and scrolling
+        /// during the animation. The animation may be stopped at any time and stops automatically
+        /// when endTime is reached. Each discrete frame that is displayed fires the
         /// <see cref="NextStepEvent"/> to enable the user of this class to provide some
         /// additional display changes or other tasks.
         /// </summary>
@@ -388,7 +388,7 @@ namespace CADability
         {
             int tc = System.Environment.TickCount;
             timeBase = tc - (currentTime - startTime) / speed * 1000.0;
-            // das war geändert in die folgende Zeile, hat vermutlich was mit Irmler zu tun. Jetzt 
+            // das war geändert in die folgende Zeile, hat vermutlich was mit Irmler zu tun. Jetzt
             // wieder rückgängig gemacht auf die obere Zeile wg. Bazzi, macht hoffentlich keine Probleme.
             //timeBase = tc;
             Frame.UIService.ApplicationIdle += new EventHandler(OnApplicationIdle);
@@ -408,8 +408,8 @@ namespace CADability
             displayLists = null;
         }
         /// <summary>
-        /// Tests the collision of two solids. The current position of the drives is applied to both objects 
-        /// (typically one of the objects is static). If there is a collision, true is returned 
+        /// Tests the collision of two solids. The current position of the drives is applied to both objects
+        /// (typically one of the objects is static). If there is a collision, true is returned
         /// and the <paramref name="collisionPoint"/> is filled with an arbitrary point where collision
         /// takes place.
         /// </summary>
@@ -691,7 +691,7 @@ namespace CADability
             if (isRunning)
             {   // hier müsste man eine Kopie des Models mit den Positionen erzeugen und dort picken
                 // und man müsste netürliche die Originalobjekte zurückliefern, was gerade bei verschachtelten
-                // Objekten (Solid, Block) recht schwierig ist. 
+                // Objekten (Solid, Block) recht schwierig ist.
                 return null;
             }
             else
@@ -758,7 +758,6 @@ namespace CADability
         {
             if (paintToOpenGl == null) return;
             IPaintTo3D ipaintTo3D = paintToOpenGl;
-            ipaintTo3D.DontRecalcTriangulation = true;
 
             ipaintTo3D.Clear(BackgroundColor);
 
@@ -1235,7 +1234,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>,
         /// returns <see cref="ShowPropertyEntryType.GroupTitle"/>.
         /// </summary>
         public override ShowPropertyEntryType EntryType
@@ -1247,7 +1246,7 @@ namespace CADability
         }
         IShowProperty[] subEntries;
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>,
         /// returns the number of subentries in this property view.
         /// </summary>
         public override int SubEntriesCount
@@ -1258,7 +1257,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>,
         /// returns the subentries in this property view.
         /// </summary>
         public override IShowProperty[] SubEntries

--- a/CADability/Face.cs
+++ b/CADability/Face.cs
@@ -181,9 +181,9 @@ namespace CADability.GeoObject
          * dann mit MakeWire die Wires, dann  mit MakeFace das Face. Solcherart erzeugte faces sind unabhängig,
          * d.h. sie müssen ggf. erst mit BRepAlgo.Sewing oder mit BRepOffsetAPI.Sewing zusammengesetzt werden.
          * Nach diesem zusammensetzen wird wieder das ganze Ding analysiert und von oben herab neu erzeugt, d.h.
-         * alte Faces und Edges werden weggeschmissen und die neuen stattdessen verwendet, wenn es ein Solid oder 
+         * alte Faces und Edges werden weggeschmissen und die neuen stattdessen verwendet, wenn es ein Solid oder
          * Shell war. Es wäre ja schön, man könnte seine Faces wiederfinden, aber wie sollte das gehen?
-         * 
+         *
          */
         private ISurface surface;
         private Edge[] outline; // die Kanten des Umrisses in richtiger Reihenfolge, die jeweilige Richtung steht in Edge
@@ -305,7 +305,7 @@ namespace CADability.GeoObject
                     surface = surface.Clone();
                     surface.ReverseOrientation(); // 2d modification is not relevant here
                 }
-                for (int i = loops.Count-1; i >=0; --i)
+                for (int i = loops.Count - 1; i >= 0; --i)
                 {
                     for (int j = loops[i].Count - 1; j >= 0; --j)
                     {
@@ -510,7 +510,7 @@ namespace CADability.GeoObject
                     }
                     if (loops[i].Count == 1 && loops[i][0].curve is Ellipse && loops[i][0].curve.IsClosed && loops[i][0].vertex1 == loops[i][0].vertex2)
                     {
-                        // a single circle must correspond to its vertex with its start/endpoint. 
+                        // a single circle must correspond to its vertex with its start/endpoint.
                         // This is not always given in step files, because they don't care about start/endpoints of circles
                         Ellipse elli = loops[i][0].curve as Ellipse;
                         if ((elli.StartPoint | loops[i][0].vertex1.Position) > Precision.eps)
@@ -729,7 +729,7 @@ namespace CADability.GeoObject
 
                             if (sameEdge && loops[i][j].curve.SameGeometry(loops[i][k].curve, Precision.eps))
                             {
-                                // two edges going in opposite directions 
+                                // two edges going in opposite directions
                                 loops[i][j].isSeam = loops[i][k].isSeam = true;
                             }
                         }
@@ -1164,7 +1164,7 @@ namespace CADability.GeoObject
                 List<Pair<StepEdgeDescriptor, List<StepEdgeDescriptor>>> splittedByPoles = new List<Pair<StepEdgeDescriptor, List<StepEdgeDescriptor>>>();
                 if (poles.Count > 0)
                 {
-                    // check whether a loop-curve goes through a pole. In this case we have to split the loop-curve into parts in order to be able to insert 
+                    // check whether a loop-curve goes through a pole. In this case we have to split the loop-curve into parts in order to be able to insert
                     // the loop-pole-curve (which is a point in 3d and a line in 2d) in between these two parts
                     // not implemented yet: the loop edge already has been splitted (multiple createdEdges)!!!
                     for (int i = 0; i < loops.Count; i++)
@@ -1470,7 +1470,7 @@ namespace CADability.GeoObject
                         sumArea += Math.Abs(area);
                         bool ccw = area > 0.0;
                         if (Math.Abs(area) < (ext.Width + ext.Height) * 1e-4 && ((i == outerLoop && !ccw) || (i != outerLoop && ccw)))
-                        {   // very slim shape for the area, step requires outer loops to be ccw and inner loops to be cw, 
+                        {   // very slim shape for the area, step requires outer loops to be ccw and inner loops to be cw,
                             // so if we should really revers a loop we better double check
                             ccw = Border.CounterClockwise(crvs);
                         }
@@ -1774,7 +1774,7 @@ namespace CADability.GeoObject
                     for (int i = 0; i < loops.Count; i++)
                     {
                         List<Edge> createdEdges = new List<Edge>();
-                        // edges might be used more than twice in step files. It is difficult then to create proper shells. 
+                        // edges might be used more than twice in step files. It is difficult then to create proper shells.
                         // here the third usage of an edge simply creates a new edge.
                         for (int j = 0; j < loops[i].Count; j++)
                         {
@@ -2552,7 +2552,7 @@ namespace CADability.GeoObject
                                     loop.Add(crvs2d[nextind]);
                                     s.Remove(nextind);
                                     currentInd = nextind;
-                                    if (loop.Count > maxCount + 4) return null; // there is an endless loop! Should never happen. 
+                                    if (loop.Count > maxCount + 4) return null; // there is an endless loop! Should never happen.
                                 }
                                 // there are some strange cases (e.g. "17044100P011 Kein Volumenmodell.stp", step index: 2561) where the seam is *part* of an edge
                                 // here we get two identical curves going for and back.
@@ -2816,7 +2816,7 @@ namespace CADability.GeoObject
                             {
                                 // this edge has been split and maybe existed before as a single edge
                                 // this single edge must now be replaced by its split parts
-                                // only the first edge in createdEdges can belong to a different face 
+                                // only the first edge in createdEdges can belong to a different face
                                 // the new created edges must use the vertices of the already defined edges
                                 if (!res.Contains(loops[i][j].createdEdges[0].PrimaryFace))
                                 {
@@ -3706,7 +3706,7 @@ namespace CADability.GeoObject
             area = null;
         }
         internal static GeoObjectList SortForWire(GeoObjectList ToSort)
-        {   // der WireMaker benötigt die Objete in der richtigen Reihenfolge, 
+        {   // der WireMaker benötigt die Objete in der richtigen Reihenfolge,
             // nicht jedoch richtig orientiert
             // noch unoptimiert, sortiert nur geschlossene
             GeoObjectList res = new GeoObjectList(ToSort.Count);
@@ -3931,7 +3931,7 @@ namespace CADability.GeoObject
         /// </summary>
         public SimpleShape Area
         {   // This is old code, which had to do a lot with incorrect imported faces from OpenCascade and with seam edges, which don't exist any more
-            // And it has to deal with a design error: all borders are counterclockwise oriented. 
+            // And it has to deal with a design error: all borders are counterclockwise oriented.
             // But in the 2d system of a face, the holes are clockwise. In a SimpleShape the holes are borders and thus counterclockwise (which was a bad idea)
             // Now we would need a new kind of border, which has no orientation preference and a new class SimpleShape, which has counterclockwise outline and clockwise holes.
             get
@@ -4094,7 +4094,7 @@ namespace CADability.GeoObject
         }
 
         /// <summary>
-        /// The name of the face. 
+        /// The name of the face.
         /// </summary>
         public string Name
         {
@@ -4493,7 +4493,7 @@ namespace CADability.GeoObject
                     Face fc = Face.MakeFace(surface, splitted[i]);
                     SimpleShape ss = fc.GetShadow(onThisPlane, this);
                     // die Kurven in ss müssen an Linien und Bögen von Zylindern und Ebenen angepasste werden
-                    // Dazu die Kreisbögen und Linien in 2d bestimmen und dann BSpline2Ds abgleichen 
+                    // Dazu die Kreisbögen und Linien in 2d bestimmen und dann BSpline2Ds abgleichen
                     if (ss != null)
                     {
                         if (cres == null) cres = new CompoundShape(ss);
@@ -6609,7 +6609,7 @@ namespace CADability.GeoObject
         }
         private void TryAssureTriangles(double precision)
         {   // es muss so gehen: der Zugriff auf trianglePoint etc muss zusätzlich gelocked werden.
-            // wenn es eine schlechte Triangulierung gibt und gerade eine bessere in Arbeit ist, dann soll man 
+            // wenn es eine schlechte Triangulierung gibt und gerade eine bessere in Arbeit ist, dann soll man
             // halt solange die schlechte nehmen
             if (Monitor.TryEnter(lockTriangulationRecalc))
             {
@@ -6668,9 +6668,7 @@ namespace CADability.GeoObject
         }
         internal void PaintFaceTo3D(IPaintTo3D paintTo3D)
         {
-            // if DontRecalcTriangulation is true, then work with the already existing triangulation, as long as there is one
-            if (!paintTo3D.DontRecalcTriangulation || trianglePoint == null)
-                TryAssureTriangles(paintTo3D.Precision);
+            TryAssureTriangles(paintTo3D.Precision);
             lock (lockTriangulationData)
             {
                 if (trianglePoint != null)
@@ -6839,7 +6837,7 @@ namespace CADability.GeoObject
             #endregion
             #region IQuadTreeInsertableZ Members
             double IQuadTreeInsertableZ.GetZPosition(GeoPoint2D p)
-            {   // das ist quick and dirty: besser mit QuadTree 
+            {   // das ist quick and dirty: besser mit QuadTree
                 double z = double.MinValue;
                 face.AssureTriangles(projection.Precision);
                 if (face.trianglePoint != null)
@@ -7055,7 +7053,7 @@ namespace CADability.GeoObject
 
             // face is connected & cube is convex
             // & cube doesn't hit any edge  (otherwise true)
-            // & cube hits surface in at least one point 
+            // & cube hits surface in at least one point
             //                              (otherwise false)
             // outside of the face          (otherwise true)
             //  =>  cube doesn't hit the face
@@ -7201,7 +7199,7 @@ namespace CADability.GeoObject
         }
         /// <summary>
         /// Returns the smallest distance from the provided point to the face. It will be the distance to
-        /// a perpendicular footpoint on the face. If there is no such perpendicular footpoint 
+        /// a perpendicular footpoint on the face. If there is no such perpendicular footpoint
         /// double.MaxValue will be returned. This method does not compute the distance to edges or vertices.
         /// If you need those distances use <see cref="ICurve.PositionOf"/> and <see cref="ICurve.PointAt"/>.
         /// </summary>
@@ -7362,11 +7360,11 @@ namespace CADability.GeoObject
                     // die Bedeutung von selections:
                     // in dem bereits richtig sortierten array der outlines werden nacheinander die
                     // einzelnen segmente umgedreht oder um die Periode verschoben, damit eine zusammenhängende Kurve
-                    // entsteht. Dazu werden die Abststände zwischen Endpunkt i und Startpunkt i+1 der verschiedenen 
+                    // entsteht. Dazu werden die Abststände zwischen Endpunkt i und Startpunkt i+1 der verschiedenen
                     // Möglichkeiten überprüft und die beste Möglichkeit wird genommen. Manchmal ist es jedoch nicht
                     // zu entscheiden, welche Möglichkeit die beste ist, und wenn man die falsche nimmt, läuft
                     // die Kurve aus dem Ruder. Selections gibtdie Liste der berechneten Abstände und ihre Codierungen an
-                    // 
+                    //
                     selections = new OrderedMultiDictionary<double, int>[outline.Length - 1];
                 }
                 // Beste Reglung: so wier hier verfahren (ohne das Verschieben in u bei zwei gleichen Linien
@@ -7415,7 +7413,7 @@ namespace CADability.GeoObject
                 // solche Linien suchen und die eine Linie um uperiod versetzen
                 /*if (uperiod != 0.0)
                 {
-                    int i0 = -1; 
+                    int i0 = -1;
                     int i1 = -1;
                     BoundingRect ext = BoundingRect.EmptyBoundingRect;
                     for (int i = 0; i < segments.Length-1; ++i)
@@ -7463,7 +7461,7 @@ namespace CADability.GeoObject
                 // Diese Umsortierung ist nicht ganz die beste Lösung. Eine Ideale Lösung würde so aussehen: Wenn der Endpunkt
                 // und der Anfangspunkt um eine oder mehrere Perioden versetzt sind, dann muss man mit dem ersten segment
                 // wieder neu beginnen und durch versetzten (allerdings um mehrere Perioden) und umdrehen versuchen den
-                // Kurvenzug zu schließen. 
+                // Kurvenzug zu schließen.
                 /*int startWith = -1;
                 if (uperiod != 0.0 && vperiod!=0.0)
                 {
@@ -8020,12 +8018,12 @@ namespace CADability.GeoObject
         internal SimpleShape GetProjectedArea(Projection p)
         {
             // PROBLEM:
-            // Der Rand einer projizierten Fläche wird aus den 3D Kurven gemacht. 
+            // Der Rand einer projizierten Fläche wird aus den 3D Kurven gemacht.
             // Es könnte Ränder geben, die sich selbst überschneiden (Schraubenflächen)
             // Aber z.Z. ist das größere Problem etwas, das z.B. beim Kegelstumpf auftritt, wenn er keine
             // Umrisskante hat. Dann ist die Umrandung durch zwei Ellipsen und zwei (identischen) Linien gegeben.
             // Es müsste daraus ein Simple Shape mit einem Loch entstehen, das ist aber z.Z. nicht der Fall.
-            // Das macht vor allem Probleme beim verdecken. 
+            // Das macht vor allem Probleme beim verdecken.
 
 
             // muss null liefern wenn in der Projektion die Fläche verschwindet, also zur Kante wird.
@@ -8043,10 +8041,10 @@ namespace CADability.GeoObject
                 if (outline[i].Curve3D != null)
                 {
                     if (outline[i].Curve3D is Ellipse && !(outline[i].Curve3D as Ellipse).IsArc)
-                    {   // Vollkreise und -Ellipsen machen Probleme, da sie zwar einen Startparameter haben, 
+                    {   // Vollkreise und -Ellipsen machen Probleme, da sie zwar einen Startparameter haben,
                         // dieser aber beim umwandeln nach 2D ignoriert wird. Der Startparameter ist aber
                         // wichtig, weil hier die anderen Kurven ansetzen (z.B. bei einem Kegelstumpf)
-                        // deshalb werden die Vollkreise in zwei halbkreise umgewandelt und als solche 
+                        // deshalb werden die Vollkreise in zwei halbkreise umgewandelt und als solche
                         // verwendet
                         ICurve[] parts = outline[i].Curve3D.Split(0.5);
                         for (int j = 0; j < parts.Length; ++j)
@@ -8119,7 +8117,7 @@ namespace CADability.GeoObject
 
             // das ist sauschade, dass an der simpleShape outline nicht mehr erkennbar ist, welche
             // Edge es mal war. Die meisten dürften unverändert bleiben und müssten nicht neu gemacht werden
-            // bei anderen würde es genügen, die Trimmstellen zu bestimmen und die Kanten zu trimmen. Nur die 
+            // bei anderen würde es genügen, die Trimmstellen zu bestimmen und die Kanten zu trimmen. Nur die
             // Tangenten sind echte neue Kanten.
 
             for (int i = 0; i < splitted.SimpleShapes.Length; ++i)
@@ -8719,7 +8717,7 @@ namespace CADability.GeoObject
         }
 
         /// <summary>
-        /// Reverses the orientation of this Face. the normal vector on any point of the surface will point to 
+        /// Reverses the orientation of this Face. the normal vector on any point of the surface will point to
         /// the opposite direction
         /// </summary>
         public void ReverseOrientation()
@@ -9237,7 +9235,7 @@ namespace CADability.GeoObject
             // jetzt werden neue faces erzeugt, indem man einmal die neuen Edges nur vorwärts und einmal nur rückwärts benutzt
             // die neuen Kanten:
             Set<Edge> intersectionEdges = new Set<Edge>();
-            // TODO: wenn splitPoints.Count nicht gerade ist, dann andere Position nehmen: 
+            // TODO: wenn splitPoints.Count nicht gerade ist, dann andere Position nehmen:
             // whileschleife, die nicht abbricht oder so...
             for (int i = 0; i < splitPoints.Count - 1; i = i + 2)
             {
@@ -9698,7 +9696,7 @@ namespace CADability.GeoObject
             {
                 //if ((replaceWith.Curve3D.StartPoint | toReplace.Curve3D.StartPoint) + (replaceWith.Curve3D.EndPoint | toReplace.Curve3D.EndPoint) >
                 //    (replaceWith.Curve3D.StartPoint | toReplace.Curve3D.EndPoint) + (replaceWith.Curve3D.EndPoint | toReplace.Curve3D.StartPoint)) fw = !fw;
-                // die beiden 3d Kurven, die eigentlich identisch sein müssen haben verschiedene Richtung. 
+                // die beiden 3d Kurven, die eigentlich identisch sein müssen haben verschiedene Richtung.
                 // Punktvergleich geht schief bei geschlossenen Kurven, deshalb Richtungsvergleich in der Mitte
                 if (replaceWith.Curve3D.DirectionAt(0.5) * toReplace.Curve3D.DirectionAt(0.5) < 0) fw = !fw;
                 else sameDirection = true;
@@ -9799,7 +9797,7 @@ namespace CADability.GeoObject
 
             Vertex v3 = replaceBy[0].StartVertex(this);
             Vertex v4 = replaceBy[replaceBy.Length - 1].EndVertex(this);
-            vertices = null; // invalidate cache 
+            vertices = null; // invalidate cache
 
             if (!toReplace.Forward(this) && !sortEdges)
             {
@@ -9883,7 +9881,7 @@ namespace CADability.GeoObject
             return false;
         }
         internal Face[] SplitAndReplace(SimpleShape ss)
-        {   // ss soll von diesem Face abgezogen werden. 
+        {   // ss soll von diesem Face abgezogen werden.
             // Es entstehen neue Faces, die das bestehende ersetzen sollen
             // vor allem die Kanten müssen gehandhabt werden
             // ss kann ganz innerhalb liegen oder auch gemeinsame Außenkanten haben
@@ -10227,7 +10225,7 @@ namespace CADability.GeoObject
             if (onThisFace.Count < 2) return edge; // there is only one (closed) edge. This should not be the case with proper (non periodic) faces
             if (onThisFace.Count > 2)
             {   // this could happen when a vertex is multiply used, but this is very rare. Another situation might be that during brep operations
-                // there are additional edges created (intersection edges) which are assiciated with this face (as primary or secondary face) but 
+                // there are additional edges created (intersection edges) which are assiciated with this face (as primary or secondary face) but
                 // do not belong to the outline or holes of this face. Such edges are dismissed here
                 int lasti = outline.Length - 1;
                 for (int i = 0; i < outline.Length; i++)
@@ -10447,7 +10445,7 @@ namespace CADability.GeoObject
         }
         /// <summary>
         /// Returns a face, that has the provided offset to this face. When dist>0 the offset will be to the outside, when dist&lt0, the offset will be to the inside
-        /// Self intersection will not be checked. 
+        /// Self intersection will not be checked.
         /// </summary>
         /// <param name="dist"></param>
         /// <returns></returns>

--- a/CADability/Model.cs
+++ b/CADability/Model.cs
@@ -56,7 +56,7 @@ namespace CADability
     }
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [Serializable]
     public class Model : IShowPropertyImpl, ISerializable, IGeoObjectOwner,
@@ -124,7 +124,7 @@ namespace CADability
         Thread manageBackgroundRecalc;
         double backgroundRecalcPrecision;
         private void RecalcGeoObject(Object state)
-        {   // wird aus dem ThreadPool heraus gestartet. 
+        {   // wird aus dem ThreadPool heraus gestartet.
             // Wenn er noch in der Liste runningThreads steht,
             // dann dort die thread id eintragen und anschließend rechnen
             // am Ende aus der Liste entfernen.
@@ -164,7 +164,7 @@ namespace CADability
         }
         private void InsertRecalcGeoObject(IGeoObject toInsert)
         {   // In die Queue von ThreadPool.QueueUserWorkItem einfügen.
-            // Gleichzeitig runningThreads aktuell halten. 
+            // Gleichzeitig runningThreads aktuell halten.
             // Hier kann man noch überlegen, wie man mit Blöcken, Blockreferenzen
             // Schraffuren, Bemaßungen umgehen soll. 3D Objekte werden auf Faces heruntergebrochen
             // da oft nur ein einziges Solid mit vielen Faces ein Modell ausmacht
@@ -268,7 +268,7 @@ namespace CADability
         internal void RecalcDisplayLists(IPaintTo3D paintTo3D)
         {   // wird vom Paint in ProjectedModel aufgerufen, wenn dieser "dirty" ist
             // kann aber nacheinander von mehreren ProjectedModels aufgerufen werden und soll nur einmal berechnet werden
-            if (paintTo3D.Precision < displayListPrecision && !paintTo3D.DontRecalcTriangulation)
+            if (paintTo3D.Precision < displayListPrecision)
             {
                 if (manageBackgroundRecalc != null)
                 {   // abbrechen und warten
@@ -287,7 +287,7 @@ namespace CADability
             if (displayListsDirty) // nur wenn kein BackgroundRecalc läuft
             {
                 // System.Diagnostics.Trace.WriteLine("displayListsDirty, Genauigkeit: " + paintTo3D.Precision.ToString());
-                if (displayListPrecision == 0.0 || (paintTo3D.Precision < displayListPrecision && !paintTo3D.DontRecalcTriangulation))
+                if (displayListPrecision == 0.0 || (paintTo3D.Precision < displayListPrecision))
                 {   // damit der Wert displayListPrecision zuverlässig gesetzt ist
                     displayListPrecision = paintTo3D.Precision;
                 }
@@ -820,7 +820,7 @@ namespace CADability
             geoObjects.MoveToBack(iGeoObject);
         }
         /// <summary>
-        /// Adds an object to this model. If the model is beeing displayed the object will appear in the view 
+        /// Adds an object to this model. If the model is beeing displayed the object will appear in the view
         /// immediately.
         /// </summary>
         /// <param name="ObjectToAdd">The GeoObject to add</param>
@@ -1082,7 +1082,7 @@ namespace CADability
         }
         /// <summary>
         /// Returns a list of all objects owned by this model. Removing or adding objects from or to the returned list doesn't remove or add
-        /// the objects from or to the model. 
+        /// the objects from or to the model.
         /// </summary>
         public GeoObjectList AllObjects
         {
@@ -1420,7 +1420,7 @@ namespace CADability
         #endregion
         #region IShowProperty
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>,
         /// returns <see cref="ShowPropertyEntryType.GroupTitle"/>.
         /// </summary>
         public override ShowPropertyEntryType EntryType
@@ -1431,7 +1431,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.LabelType"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.LabelType"/>,
         /// </summary>
         public override ShowPropertyLabelFlags LabelType
         {
@@ -1495,7 +1495,7 @@ namespace CADability
         }
         IShowProperty[] subEntries;
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>,
         /// returns the number of subentries in this property view.
         /// </summary>
         public override int SubEntriesCount
@@ -1506,7 +1506,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>,
         /// returns the subentries in this property view.
         /// </summary>
         public override IShowProperty[] SubEntries
@@ -1753,7 +1753,7 @@ namespace CADability
         }
         #region Query Objects
         /// <summary>
-        /// Returns all objects of the model that are touched by the <paramref name="pickrect"/>, whos layers are in the 
+        /// Returns all objects of the model that are touched by the <paramref name="pickrect"/>, whos layers are in the
         /// <paramref name="visibleLayers"/> set and which are accepted by the <paramref name="filterList"/>.
         /// </summary>
         /// <param name="pickrect">Area that specifies which objects are beeing tested</param>
@@ -1957,7 +1957,7 @@ namespace CADability
             return res;
         }
         /// <summary>
-        /// Returns all objects of the model that are touched by the <paramref name="area"/>, whos layers are in the 
+        /// Returns all objects of the model that are touched by the <paramref name="area"/>, whos layers are in the
         /// <paramref name="visibleLayers"/> set and which are accepted by the <paramref name="filterList"/>.
         /// </summary>
         /// <param name="area">Area that specifies which objects are beeing tested</param>
@@ -2222,7 +2222,7 @@ namespace CADability
                 l[i].FindSnapPoint(spf);
             }
             // die Überprüfung der Schnittpunkte erfolgt hier in einer Doppelschleife
-            // das wird nicht den einzelnen Objekten überlassen, da die nichts von 
+            // das wird nicht den einzelnen Objekten überlassen, da die nichts von
             // den andern Objekten wissen.
             if (spf.SnapToIntersectionPoint)
             {
@@ -2313,7 +2313,7 @@ namespace CADability
                 l[i].FindSnapPoint(spf);
             }
             // die Überprüfung der Schnittpunkte erfolgt hier in einer Doppelschleife
-            // das wird nicht den einzelnen Objekten überlassen, da die nichts von 
+            // das wird nicht den einzelnen Objekten überlassen, da die nichts von
             // den andern Objekten wissen.
             if (spf.SnapToIntersectionPoint)
             {

--- a/CADability/ModelView.cs
+++ b/CADability/ModelView.cs
@@ -64,7 +64,7 @@ namespace CADability
         /// <returns></returns>
         IView GetView();
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="mousePosition"></param>
         /// <returns></returns>
@@ -163,7 +163,7 @@ namespace CADability
         }
         #region IShowProperty Members
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>,
         /// returns <see cref="ShowPropertyEntryType.GroupTitle"/>.
         /// </summary>
         public override ShowPropertyEntryType EntryType
@@ -184,7 +184,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>,
         /// returns the number of subentries in this property view.
         /// </summary>
         public override int SubEntriesCount
@@ -196,7 +196,7 @@ namespace CADability
         }
         IShowProperty[] subEntries;
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>,
         /// returns the subentries in this property view.
         /// </summary>
         public override IShowProperty[] SubEntries
@@ -800,7 +800,6 @@ namespace CADability
 
                 try
                 {
-                    if (projectedModel.supressAutoRegeneration) (paintTo3D).DontRecalcTriangulation = true;
                     projectedModel.Paint(paintTo3D);
                     PaintBackground(paintTo3D);
                     paintTo3D.UseZBuffer(false);
@@ -814,7 +813,6 @@ namespace CADability
                     if (Settings.GlobalSettings.GetBoolValue("ActionActiveObject.UseZBuffer", true)) paintTo3D.UseZBuffer(true);
                     if (PaintActiveEvent != null) PaintActiveEvent(e.ClipRectangle, this, paintTo3D);
                     if (PaintSelectEvent != null) PaintSelectEvent(e.ClipRectangle, this, paintTo3D);
-                    paintTo3D.DontRecalcTriangulation = false;
                 }
                 catch (PaintTo3DOutOfMemory)
                 {
@@ -1355,7 +1353,7 @@ namespace CADability
         }
         void IView.InvalidateAll()
         {
-            // ForceInvalidateAll(); // das ist definitiv zuviel, bei FeedbackObjekten wird das aufgerufen und es bräuchte nur ein 
+            // ForceInvalidateAll(); // das ist definitiv zuviel, bei FeedbackObjekten wird das aufgerufen und es bräuchte nur ein
             // neuzeichnen der Feedback Objekte
             canvas?.Invalidate();
         }
@@ -1507,7 +1505,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.EntryType"/>,
         /// returns <see cref="ShowPropertyEntryType.GroupTitle"/>.
         /// </summary>
         public override ShowPropertyEntryType EntryType
@@ -1553,7 +1551,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="PropertyEntryImpl.ContextMenu"/>, 
+        /// Overrides <see cref="PropertyEntryImpl.ContextMenu"/>,
         /// returns the context menu with the id "MenuId.ModelView".
         /// (see <see cref="MenuResource.LoadContextMenu"/>)
         /// </summary>
@@ -1569,7 +1567,7 @@ namespace CADability
 
         IShowProperty[] subEntries;
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntriesCount"/>,
         /// returns the number of subentries in this property view.
         /// </summary>
         public override int SubEntriesCount
@@ -1580,7 +1578,7 @@ namespace CADability
             }
         }
         /// <summary>
-        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>, 
+        /// Overrides <see cref="IShowPropertyImpl.SubEntries"/>,
         /// returns the subentries in this property view.
         /// </summary>
         public override IShowProperty[] SubEntries
@@ -1891,18 +1889,6 @@ namespace CADability
                 ForceInvalidateAll();
                 canvas?.Invalidate();
                 RecalcScrollPosition();
-            }
-        }
-        public bool SupressAutoRegeneration
-        {
-            get
-            {
-                return projectedModel.supressAutoRegeneration;
-            }
-            set
-            {
-                projectedModel.supressAutoRegeneration = value;
-                canvas?.Invalidate();
             }
         }
 

--- a/CADability/PaintToOpenGl.cs
+++ b/CADability/PaintToOpenGl.cs
@@ -103,10 +103,6 @@ namespace CADability
         /// </summary>
         bool TriangulateText { get; }
         /// <summary>
-        /// Deprecated, currently not used
-        /// </summary>
-        bool DontRecalcTriangulation { get; set; }
-        /// <summary>
         /// Returns the capabilities of this implementation of the paint interface
         /// </summary>
         PaintCapabilities Capabilities { get; }
@@ -195,7 +191,7 @@ namespace CADability
         /// <summary>
         /// Draws a rectangular bitmap at the provided <paramref name="location"/> with <paramref name="directionWidth"/>
         /// specifying the direction of the lower edge of the bitmap and <paramref name="directionHeight"/>
-        /// specifying the direction of the left edge of the bitmap. <see cref="PrepareBitmap"/> must be called 
+        /// specifying the direction of the left edge of the bitmap. <see cref="PrepareBitmap"/> must be called
         /// before this method is called.
         /// </summary>
         /// <param name="bitmap">The bitmap to draw</param>
@@ -294,7 +290,7 @@ namespace CADability
         void Resize(int width, int height);
         /// <summary>
         /// Opens a new display list. All subsequent calls to paint methods will be stred in the list. When
-        /// <see cref="CloseList"/> will be called the object resembling the list will be returned. Only the following 
+        /// <see cref="CloseList"/> will be called the object resembling the list will be returned. Only the following
         /// method calls are allowed while a displaylist is open: <see cref="Polyline"/>, <see cref="FilledPolyline"/>,
         /// <see cref="Points"/>, <see cref="Triangle"/>, <see cref="RectangularBitmap"/>, <see cref="Text"/>,
         /// <see cref="DisplayIcon"/>, <see cref="DisplayBitmap"/>, <see cref="List"/>
@@ -672,7 +668,7 @@ namespace CADability
     {
         /// <summary>
         /// Delegate definition of <see cref="SetProjectionEvent"/>.
-        /// 
+        ///
         /// </summary>
         /// <param name="renderContext">The OpenGL render context</param>
         /// <param name="paintTo3D">The IPaintTo3D interface of the instance beeing involved</param>
@@ -731,7 +727,7 @@ namespace CADability
             //projection.Precision = bc.Size * 1e-3;
 
             //BoundingRect ext = bc.GetExtent(projection); //  list.GetExtent(projection, true, false);
-            //ext = ext * 1.1; // inflate by 10 percent 
+            //ext = ext * 1.1; // inflate by 10 percent
             //projection.SetPlacement(new Rectangle(0, 0, bmp.Width, bmp.Height), ext);
 
             //ipaintTo3D.SetProjection(projection, bc);

--- a/CADability/PaintToSTL.cs
+++ b/CADability/PaintToSTL.cs
@@ -129,18 +129,6 @@ namespace CADability
             get { return false; }
         }
 
-        bool IPaintTo3D.DontRecalcTriangulation
-        {
-            get
-            {
-                return false;
-            }
-            set
-            {
-                throw new NotImplementedException();
-            }
-        }
-
         PaintCapabilities IPaintTo3D.Capabilities
         {
             get { return PaintCapabilities.Standard; }

--- a/CADability/PrintToGDI.cs
+++ b/CADability/PrintToGDI.cs
@@ -434,7 +434,7 @@ namespace CADability
                     commonPoint = tp23;
                     return true;
                 }
-                // jetzt der umgekehrte Test 
+                // jetzt der umgekehrte Test
                 ModOp2D toTr2 = new ModOp2D(tp22 - tp21, tp23 - tp21, tp21);
                 ModOp2D fromTr2 = toTr2.GetInverse(); // ist relativ schnell
 
@@ -1028,7 +1028,7 @@ namespace CADability
         {
             List<PrintTriangle> result = new List<PrintTriangle>();
             List<PrintTriangle> result2 = new List<PrintTriangle>();
-            // Finde Strecke mit zwei Schnittpunkten   
+            // Finde Strecke mit zwei Schnittpunkten
             GeoPoint2D x1 = new GeoPoint2D(points[i0]);
             GeoPoint2D y1 = new GeoPoint2D(points[i1]);
             GeoPoint2D z1 = new GeoPoint2D(points[i2]);
@@ -1099,7 +1099,7 @@ namespace CADability
             {
 
                 gr.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.HighQuality;
-                gr.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;//HighQuality; 
+                gr.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.None;//HighQuality;
                 //if (true)
                 if (flat)
                 {
@@ -1223,7 +1223,7 @@ namespace CADability
                     gr.FillPolygon(br, pnts);
                     /*
                     Pen colorpen = new Pen(br, (float)0.0);
-                    gr.DrawPolygon(colorpen, pnts);  
+                    gr.DrawPolygon(colorpen, pnts);
                     // brush freigeben
                     colorpen.Dispose();
                     //*/
@@ -1569,7 +1569,7 @@ namespace CADability
             currentGraphics.Transform = new System.Drawing.Drawing2D.Matrix((float)(plfact), 0.0f, 0.0f, (float)(-plfact), (float)dx, (float)dy);
             // projection = new Matrix4(new double[,] { { plfact, 0, 0, dx }, { 0, plfact, 0, dy }, { 0, 0, plfact, 0.0 }, { 0, 0, 0, 1 } }) * projection;
             currentPrecision = 1.0 / plfact;//0.1; // noch vernünftig setzen
-            //currentCollection = new OctTree<IPrintItemImpl>(lp.Model.Extent, 0.1); // Parameter noch falsch             
+            //currentCollection = new OctTree<IPrintItemImpl>(lp.Model.Extent, 0.1); // Parameter noch falsch
             currentCollectionList = new List<IPrintItemImpl>();
             currentCollectionQuad = new QuadTree<IPrintItemImpl>(new BoundingRect(model.Extent.Xmin, model.Extent.Ymin, model.Extent.Xmax, model.Extent.Ymax));
             // Sorgt nicht fuer eine Verbesserung
@@ -1671,7 +1671,7 @@ namespace CADability
                         pr.GetPlacement(out plfact, out dx, out dy);
                         projection = new Matrix4(new double[,] { { plfact, 0, 0, dx }, { 0, plfact, 0, dy }, { 0, 0, plfact, 0.0 }, { 0, 0, 0, 1 } }) * projection;
                         currentPrecision = 0.5;//0.1; // noch vernünftig setzen
-                                               //currentCollection = new OctTree<IPrintItemImpl>(lp.Model.Extent, 0.1); // Parameter noch falsch             
+                                               //currentCollection = new OctTree<IPrintItemImpl>(lp.Model.Extent, 0.1); // Parameter noch falsch
                         currentCollectionList = new List<IPrintItemImpl>();
                         currentCollectionQuad = new QuadTree<IPrintItemImpl>(new BoundingRect(lp.Model.Extent.Xmin, lp.Model.Extent.Ymin, lp.Model.Extent.Xmax, lp.Model.Extent.Ymax));
                         // Sorgt nicht fuer eine Verbesserung
@@ -1777,7 +1777,7 @@ namespace CADability
                     pr.GetPlacement(out plfact, out dx, out dy);
                     // projection = new Matrix4(new double[,] { { plfact, 0, 0, dx }, { 0, plfact, 0, dy }, { 0, 0, plfact, 0.0 }, { 0, 0, 0, 1 } }) * projection;
                     currentPrecision = 0.5;//0.1; // noch vernünftig setzen
-                                           //currentCollection = new OctTree<IPrintItemImpl>(lp.Model.Extent, 0.1); // Parameter noch falsch             
+                                           //currentCollection = new OctTree<IPrintItemImpl>(lp.Model.Extent, 0.1); // Parameter noch falsch
                     currentCollectionList = new List<IPrintItemImpl>();
                     currentCollectionQuad = new QuadTree<IPrintItemImpl>(new BoundingRect(gdiView.Model.Extent.Xmin, gdiView.Model.Extent.Ymin, gdiView.Model.Extent.Xmax, gdiView.Model.Extent.Ymax));
                     // Sorgt nicht fuer eine Verbesserung
@@ -2191,7 +2191,7 @@ namespace CADability
                 res = new Pen(clr, (float)(currentLineWidth.Width * lineWidthFactor * currentProjection.WorldToDeviceFactor));
             else
                 res = new Pen(clr, 1.0f);
-            if (res.Width == 0.0) res.Width = 0.1f; // 0.1 mm als dünnste Linie, ist wichtig bei Drucken über Bitmap 
+            if (res.Width == 0.0) res.Width = 0.1f; // 0.1 mm als dünnste Linie, ist wichtig bei Drucken über Bitmap
             if (currentLinePattern != null && currentLinePattern.Pattern.Length > 0)
             {
                 float[] fpattern = new float[currentLinePattern.Pattern.Length];
@@ -2430,7 +2430,7 @@ namespace CADability
 
         void IPaintTo3D.Points(GeoPoint[] points, float size, PointSymbol pointSymbol)
         {
-            
+
         }
 
         void IPaintTo3D.Triangle(GeoPoint[] vertex, GeoVector[] normals, int[] indextriples)
@@ -2832,21 +2832,6 @@ namespace CADability
 
 #region IPaintTo3D Member
 
-
-        public bool DontRecalcTriangulation
-        {
-            get
-            {
-                return false;
-                //throw new NotImplementedException();
-            }
-            set
-            {
-                //throw new NotImplementedException();
-            }
-        }
-
-        bool IPaintTo3D.DontRecalcTriangulation { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
         bool IPaintTo3D.IsBitmap => throw new NotImplementedException();
 

--- a/CADability/ProjectedModel.cs
+++ b/CADability/ProjectedModel.cs
@@ -27,24 +27,24 @@ namespace CADability
     internal delegate void NeedsRepaintDelegate(object Sender, NeedsRepaintEventArg Arg);
 
     /* KONZEPT Sichtbarkeit für Kanten:
-     * 
+     *
      * Das ProjectedModel sollte alle Objekte halten, die mit der Kantensichtbarkeit zu tun haben, da diese
      * Objekte mit dem ProjectedModel die gleiche Lebensdauer haben:
-     * 
+     *
      * Face->Edge[] ContourEdges
      * Edge->ProjectedEdge Sichtbarkeit einer Kante
-     * 
+     *
      * ProjectedModel bekommt einen Aufruf RecalcVisible, mit dem diese Dictionaries erzeugt werden.
      * Dabei werden alle Faces untersucht, und wenn noch nicht vorhanden die tangentialen Konturkanten berechnet.
      * Aus diesen und den echten Umrissen eines Faces werden für jedes Face ein CompoundShape in u/v und ein solches in x/y
-     * berechnet. Jede Kante gehört zu einem oder zwei SimpleShapes. Kanten von Faces mit tangentialen Konturkanten 
+     * berechnet. Jede Kante gehört zu einem oder zwei SimpleShapes. Kanten von Faces mit tangentialen Konturkanten
      * müssen aufgeteilt werden, also brauchen wir noch ein Dictionary von Kante auf aufgeteilte Kante.
-     * 
+     *
      * Die einzelnen Kanten werden dann durch diese Flächen (SimpleShapes) verdeckt, natürlich nur durch die Flächen, an
      * denen sie selbst nicht beteilgt sind. Dann werden sie entsprechend ihrer Sichtbarkeit dargestellt.
-     * 
+     *
      * Wenn man das verdecken von SimpleShapes miteinander zulässt, dann kann man die Flächen auch im Inneren pickbar machen.
-     * 
+     *
      */
 
     /// <summary>
@@ -61,7 +61,7 @@ namespace CADability
 
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
     [Serializable]
     public class ProjectedModel : ISerializable, IDeserializationCallback
@@ -69,13 +69,13 @@ namespace CADability
         static bool DoBackgroundPaint = false; // immer false, keine Hidden lines mehr!
         #region Konzept:
         /*	Konzept zum ProjectedModel:
-		 * Die Klasse ProjectedModel hält einen QuadTree, der die Objekte für die 2D Darstellung enthält. 
+		 * Die Klasse ProjectedModel hält einen QuadTree, der die Objekte für die 2D Darstellung enthält.
 		 * Diese Objekte vom Typ I2DRepresentation sind "Ableger" der GeoObjekte. Mit einer HashTabelle
 		 * geoObjects2D kommt man von einem GeoObjekt zu seinem oder seinen I2DRepresentation Objekten.
 		 * Diese sind alleine Ausschlaggebend für die Darstellung. Sie beinhalten bereits die Projektion
 		 * (als UnscaledProjection) und müssen oft garnicht mehr auf ihr zugehöriges GeoObjekt zur
 		 * Darstellung zurückgreifen.
-		 * Wenn sich die Geometrie eines GeoObjects ändert, so wird es bei WillChange aus dem QuadTree entfernt 
+		 * Wenn sich die Geometrie eines GeoObjects ändert, so wird es bei WillChange aus dem QuadTree entfernt
 		 * und bei DidChange wieder dort eingefügt.
 		 * Wenn sich nur das Attribut ändert, so dass das Objekt im QuadTree verbleiben kann
 		 * dann ...fehlt noch das Konzept...
@@ -98,7 +98,6 @@ namespace CADability
         private BoundingRect extent; // die Ausdehnung in der 2D Welt, wenn leer, dann noch nicht berechnet
         private BoundingRect workSpace; // wird z.B.von PfoCAD verwendet, um eine Arbeitsfläche zu definieren
         private bool useLineWidth; // !"nur dünne Linien", muss noch implementiert werden
-        internal bool supressAutoRegeneration;
         private int dbg;
         static private int dbgcnt = 0;
 
@@ -156,7 +155,6 @@ namespace CADability
         {
             model = m;
             projection = pr;
-            supressAutoRegeneration = false;
             geoObjects = new Dictionary<int, IGeoObject>();
             extent = BoundingRect.EmptyBoundingRect;
             model.GeoObjectAddedEvent += new CADability.Model.GeoObjectAdded(GeoObjectAddedEvent);
@@ -571,7 +569,7 @@ namespace CADability
                 l[i].FindSnapPoint(spf);
             }
             // die Überprüfung der Schnittpunkte erfolgt hier in einer Doppelschleife
-            // das wird nicht den einzelnen Objekten überlassen, da die nichts von 
+            // das wird nicht den einzelnen Objekten überlassen, da die nichts von
             // den andern Objekten wissen.
             if (spf.SnapToIntersectionPoint)
             {
@@ -1026,7 +1024,7 @@ namespace CADability
         //            if (qi is QuadTreeCollection && qi.ReferencedObject is Block)
         //            {
         //                IQuadTreeInsertable[] sub = (qi as QuadTreeCollection).GetObjectsFromRect(ref pickrect);
-        //                // das liefert auf unterster Ebene, 
+        //                // das liefert auf unterster Ebene,
         //                // wir wollen hier aber Pfade und andere "NichtBlöcke" zusammenhalten
         //                for (int i = 0; i < sub.Length; ++i)
         //                {
@@ -1118,7 +1116,7 @@ namespace CADability
         #region Helper Methods
         public enum IntersectionMode { OnlyInside, BothExtensions, StartExtension, EndExtension, InsideAndSelfIntersection }
         /// <summary>
-        /// Returns the parameters for all intersection point of this curve with other 
+        /// Returns the parameters for all intersection point of this curve with other
         /// curves in the model. The curve must be planar. To get the 3D intersection point
         /// call <see cref="ICurve.PointAt"/>. If CheckExtension is true, there will also be
         /// intersection parameters in the extension of the curve (if the curve can extend)
@@ -1178,7 +1176,7 @@ namespace CADability
                             {
                                 // bei Kreisbögen ist die Frage bei einem Schnittpunkt außerhalb
                                 // ob man diesen als Schnittpunkt vor dem Anfang oder nach dem Ende
-                                // betrachten soll. Wenn IntersectionMode.StartExtension oder 
+                                // betrachten soll. Wenn IntersectionMode.StartExtension oder
                                 // IntersectionMode.EndExtension gegeben sind, dann werden solche Punkte
                                 // hier noch korrigiert. (c1 ist die Ausgangskurve, deshalb par1)
                                 if (mode == IntersectionMode.StartExtension)
@@ -1293,7 +1291,7 @@ namespace CADability
         //}
         internal void Paint(IPaintTo3D paintTo3D)
         {
-            // Nur das Modell darstellen. Die anderen Aspekte (Raster, aktive Objekte, Selektion) werden von 
+            // Nur das Modell darstellen. Die anderen Aspekte (Raster, aktive Objekte, Selektion) werden von
             // ModelView abgehandelt
 
             // recalcVisibility ist true, wenn die Sichtbarkeit der Layer umgeschaltet wurde
@@ -1303,7 +1301,7 @@ namespace CADability
             // schneller geht.
 
             paintTo3D.PaintFaces(PaintTo3D.PaintMode.All);
-            if (dirty || (!supressAutoRegeneration && model.displayListPrecision > paintTo3D.Precision))
+            if (dirty || (model.displayListPrecision > paintTo3D.Precision))
             {   // die Dictionaries Layer->Displaylist neu machen
                 model.RecalcDisplayLists(paintTo3D);
                 dirty = true;
@@ -1319,7 +1317,7 @@ namespace CADability
                         allFaces.Add(kv.Value);
                     }
                 }
-                
+
                 allTransparent.Clear();
                 foreach (KeyValuePair<Layer, IPaintTo3DList> kv in model.layerTransparentDisplayList)
                 {
@@ -1358,7 +1356,7 @@ namespace CADability
             paintTo3D.PaintFaces(PaintTo3D.PaintMode.CurvesOnly); // moves the curves a small distance to the front
             foreach (IPaintTo3DList plist in allCurves) paintTo3D.List(plist);
             if (projection.ShowFaces)
-            {   
+            {
                 paintTo3D.PaintFaces(PaintTo3D.PaintMode.FacesOnly); // moves the faces a small distance to the back
                 foreach (IPaintTo3DList plist in allFaces) paintTo3D.List(plist);
                 paintTo3D.Blending(true);
@@ -1373,7 +1371,7 @@ namespace CADability
 
             //    if (recalcVisibility && layerListGenerated)
             //    {   // hier wird aus den existierenden LayerListen die Liste aller sichtbaren faces und aller
-            //        // sichtbaren edges (Kurven) berechnet und 
+            //        // sichtbaren edges (Kurven) berechnet und
             //        recalcVisibility = false;
             //        List<IPaintTo3DList> allGeoObjects = new List<IPaintTo3DList>();
             //        foreach (KeyValuePair<Layer,IPaintTo3DList> kv in layerFaceDisplayList)


### PR DESCRIPTION
This property always defaults to "false" or even throws NotImplementedExceptions. I should therefore be removed.