### PR TITLE
Fixed reference to Visual Studio Debugger assembly

### DIFF
--- a/CADability/CADability.csproj
+++ b/CADability/CADability.csproj
@@ -93,7 +93,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers">
-      <HintPath>..\..\..\..\..\..\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.DebuggerVisualizers.dll</HintPath>
+      <HintPath>$(VsInstallRoot)\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.DebuggerVisualizers.dll</HintPath>
     </Reference>
   </ItemGroup>
 


### PR DESCRIPTION
The bug was causing compile errors due to wrong hint path