### PR TITLE
Fix error The number of control points must be the same as the number…

### DIFF
--- a/CADability/ExportDxf.cs
+++ b/CADability/ExportDxf.cs
@@ -164,13 +164,11 @@ namespace CADability.DXF
             {
                 for (int j = 0; j < bspline.Multiplicities[i]; j++) knots.Add(bspline.Knots[i]);
             }
-
-            //TODO: Check if bspline.IsClosed means the same as Spline.IsClosedPeriodic
-            //TODO: Check if it's okay to pass an empty array as weights
+                        
             if (bspline.HasWeights)
                 return new netDxf.Entities.Spline(poles, bspline.Weights, knots, (short)bspline.Degree, bspline.IsClosed);
             else
-                return new netDxf.Entities.Spline(poles, Array.Empty<double>(), knots, (short)bspline.Degree, bspline.IsClosed);
+                return new netDxf.Entities.Spline(poles, null, knots, (short)bspline.Degree, bspline.IsClosed);
         }
 
         private netDxf.Entities.Polyline3D ExportPolyline(GeoObject.Polyline polyline)


### PR DESCRIPTION
Wrong parameter was set here. It should be null if the spline has no weights.

https://github.com/SOFAgh/CADability/blob/0117f6f3d4bac7c8c10f3e1bf05f3fe8e248dd7c/CADability/ExportDxf.cs#L170-L173

Fix the error:

Exception Source:      CADability
Exception Type:        System.ArgumentException
Exception Message:     The number of control points must be the same as the number of weights.
Parametername: weights
Exception Target Site: .ctor

---- Stack Trace ----
   netDxf.Entities.Spline..ctor(controlPoints As IEnumerable`1, weights As IEnumerable`1, knots As IEnumerable`1, degree As Int16, fitPoints As IEnumerable`1, method As SplineCreationMethod, closedPeriodic As Boolean)
       Spline.cs: line 0286, col 17
   netDxf.Entities.Spline..ctor(controlPoints As IEnumerable`1, weigths As IEnumerable`1, knots As IEnumerable`1, degree As Int16, closedPeriodic As Boolean)
       Spline.cs: line 0220, col 15
   CADability.DXF.Export.ExportBSpline(bspline As BSpline)
       ExportDxf.cs: line 0173, col 17
   CADability.DXF.Export.GeoObjectToEntity(geoObject As IGeoObject)
       ExportDxf.cs: line 0053, col 49
   CADability.DXF.Export.WriteToFile(toExport As Project, filename As String)
       ExportDxf.cs: line 0038, col 17
   CADability.Project.Export(fileName As String, format As String)
       Project.cs: line 1210, col 21
   LogiCal.WiCamExportHelper.SaveCadDrawing(pos As Position, filename As String)
       WiCamExportHelper.cs: line 0445, col 17
   LogiCal.WiCamExportHelper.ProcessPosition(keepOrigFileName As Boolean, PosCount As Int32&, sb As StringBuilder, pos As Position)
       WiCamExportHelper.cs: line 0366, col 25
   LogiCal.WiCamExportHelper.FillCsvDetailsPart(keepOrigFileName As Boolean)
       WiCamExportHelper.cs: line 0283, col 35
   LogiCal.WiCamExportHelper.FillCsvContent(keepOrigFileName As Boolean)
       WiCamExportHelper.cs: line 0210, col 13
   LogiCal.WiCamExportHelper.MakeCsv(csvFile As String, keepOrigFileName As Boolean, saveCsv As Boolean)
       WiCamExportHelper.cs: line 0107, col 13
   LogiCal.WiCamExportHelper.ExportToWiCam(outputPath As String, keepOrigFileName As Boolean, saveCsv As Boolean)
       WiCamExportHelper.cs: line 0090, col 17
   LogiCal.MainForms.Orders.<>c__DisplayClass720_0.<bbiExportWiCam_ItemClick>b__0()
       frmAuftrag.cs: line 4175, col 21
   System.Threading.ExecutionContext.RunInternal(executionContext As ExecutionContext, callback As ContextCallback, state As Object, preserveSyncCtx As Boolean)
       : N 00370
   System.Threading.ExecutionContext.Run(executionContext As ExecutionContext, callback As ContextCallback, state As Object, preserveSyncCtx As Boolean)
       : N 00021
   System.Threading.ExecutionContext.Run(executionContext As ExecutionContext, callback As ContextCallback, state As Object)
       : N 00085
   System.Threading.ThreadHelper.ThreadStart()
       : N 00085
