### PR TITLE
Add cases for Abort and Finish for the OnCommand

### DIFF
--- a/CADability/RotateObjects.cs
+++ b/CADability/RotateObjects.cs
@@ -202,6 +202,12 @@ namespace CADability.Actions
                     axisVector = GeoVector.ZAxis;
                     SetRefPoint(BasePoint); // zum Updaten
                     return true;
+                case "MenuId.Construct.Abort":
+                    this.OnEscape();
+                    return true;
+                case "MenuId.Construct.Finish":
+                    this.OnEnter();
+                    return true;
             }
             return false;
         }


### PR DESCRIPTION
The OnCommand was missing cases for Abort and Finish.

https://github.com/SOFAgh/CADability/blob/914df4e8548a4680e87a66f10fc9389dfa228545/CADability/RotateObjects.cs#L189-L213

Close #41 