### PR TITLE
Update netDXF to latest version 01.Nov.2022

### DIFF
--- a/CADability/netDxf/Blocks/Block.cs
+++ b/CADability/netDxf/Blocks/Block.cs
@@ -359,12 +359,21 @@ namespace netDxf.Blocks
         }
 
         /// <summary>
+        /// Gets the owner of the actual DXF object.
+        /// </summary>
+        public new BlockRecord Owner
+        {
+            get { return (BlockRecord) base.Owner; }
+            internal set { base.Owner = value; }
+        }
+
+        /// <summary>
         /// Gets the block record associated with this block.
         /// </summary>
         /// <remarks>It returns the same object as the owner property.</remarks>
         public BlockRecord Record
         {
-            get { return (BlockRecord) this.Owner; }
+            get { return this.Owner; }
         }
 
         /// <summary>

--- a/CADability/netDxf/Collections/DrawingEntities.cs
+++ b/CADability/netDxf/Collections/DrawingEntities.cs
@@ -418,7 +418,7 @@ namespace netDxf.Collections
             {
                 return false;
             }
-            
+
             // if an entity belongs to a document always has a handle
             Debug.Assert(entity.Handle != null, "The entity has no handle.");
 

--- a/CADability/netDxf/Collections/TableObjects.cs
+++ b/CADability/netDxf/Collections/TableObjects.cs
@@ -78,11 +78,7 @@ namespace netDxf.Collections
         /// <remarks>Table object names are case insensitive.</remarks>
         public T this[string name]
         {
-            get
-            {
-                T item;
-                return this.list.TryGetValue(name, out item) ? item : null;
-            }
+            get { return this.list.TryGetValue(name, out T item) ? item : null; }
         }
 
         /// <summary>

--- a/CADability/netDxf/Entities/Ellipse.cs
+++ b/CADability/netDxf/Entities/Ellipse.cs
@@ -217,7 +217,11 @@ namespace netDxf.Entities
         /// <param name="center">Ellipse <see cref="Vector2">center</see> in object coordinates.</param>
         /// <param name="majorAxis">Ellipse major axis.</param>
         /// <param name="minorAxis">Ellipse minor axis.</param>
-        /// <remarks>The center Z coordinate represents the elevation of the arc along the normal.</remarks>
+        /// <remarks>
+        /// The center Z coordinate represents the elevation of the ellipse along the normal.
+        /// The major axis is always measured along the ellipse local X axis,
+        /// while the minor axis is along the local Y axis.
+        /// </remarks>
         public Ellipse(Vector2 center, double majorAxis, double minorAxis)
             : this(new Vector3(center.X, center.Y, 0.0), majorAxis, minorAxis)
         {
@@ -229,7 +233,11 @@ namespace netDxf.Entities
         /// <param name="center">Ellipse <see cref="Vector3">center</see> in object coordinates.</param>
         /// <param name="majorAxis">Ellipse major axis.</param>
         /// <param name="minorAxis">Ellipse minor axis.</param>
-        /// <remarks>The center Z coordinate represents the elevation of the arc along the normal.</remarks>
+        /// <remarks>
+        /// The center Z coordinate represents the elevation of the ellipse along the normal.
+        /// The major axis is always measured along the ellipse local X axis,
+        /// while the minor axis is along the local Y axis.
+        /// </remarks>
         public Ellipse(Vector3 center, double majorAxis, double minorAxis)
             : base(EntityType.Ellipse, DxfObjectCode.Ellipse)
         {
@@ -274,35 +282,19 @@ namespace netDxf.Entities
         /// <summary>
         /// Gets or sets the ellipse mayor axis.
         /// </summary>
-        /// <remarks>The MajorAxis value must be positive and greater than the MinorAxis.</remarks>
+        /// <remarks>The major axis is always measured along the ellipse local X axis.</remarks>
         public double MajorAxis
         {
             get { return this.majorAxis; }
-            //set
-            //{
-            //    if (value <= 0)
-            //    {
-            //        throw new ArgumentOutOfRangeException(nameof(value), value, "The major axis value must be greater than zero.");
-            //    }
-            //    this.majorAxis = value;
-            //}
         }
 
         /// <summary>
         /// Gets or sets the ellipse minor axis.
         /// </summary>
-        /// <remarks>The MinorAxis value must be positive and smaller than the MajorAxis.</remarks>
+        /// <remarks>The minor axis is always measured along the ellipse local Y axis.</remarks>
         public double MinorAxis
         {
             get { return this.minorAxis; }
-            //set
-            //{
-            //    if (value <= 0)
-            //    {
-            //        throw new ArgumentOutOfRangeException(nameof(value), value, "The minor axis value must be greater than zero.");
-            //    }
-            //    this.minorAxis = value;
-            //}
         }
 
         /// <summary>
@@ -357,29 +349,35 @@ namespace netDxf.Entities
         #region public methods
 
         /// <summary>
-        /// Sets the ellipse major and minor axis.
+        /// Sets the ellipse major and minor axis from the two parameters.
         /// </summary>
-        /// <param name="major">Ellipse major axis.</param>
-        /// <param name="minor">Ellipse minor axis.</param>
-        public void SetAxis(double major, double minor)
+        /// <param name="axis1">Ellipse axis.</param>
+        /// <param name="axis2">Ellipse axis.</param>
+        /// <remarks>
+        /// It is not required that axis1 is greater than axis2. The larger value will be assigned as major axis and the lower as minor axis.
+        /// </remarks>
+        public void SetAxis(double axis1, double axis2)
         {
-            if (major <= 0)
+            if (axis1 <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(major), major, "The major axis value must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(axis1), axis1, "The axis value must be greater than zero.");
             }
 
-            if (minor <= 0)
+            if (axis2 <= 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(minor), minor, "The minor axis value must be greater than zero.");
+                throw new ArgumentOutOfRangeException(nameof(axis2), axis2, "The axis value must be greater than zero.");
             }
 
-            if ( minor > major)
+            if (axis2 > axis1)
             {
-                throw new ArgumentException("The ellipse major axis must be greater than the minor axis.");
+                this.majorAxis = axis2;
+                this.minorAxis = axis1;
             }
-
-            this.majorAxis = major;
-            this.minorAxis = minor;
+            else
+            {
+                this.majorAxis = axis1;
+                this.minorAxis = axis2;
+            }
         }
 
         /// <summary>
@@ -581,7 +579,7 @@ namespace netDxf.Entities
                 axis2 = MathHelper.IsZero(axis2) ? MathHelper.Epsilon : axis2;
 
                 this.Center = transformation * this.Center + translation;
-                this.SetAxis(axis2, axis1);
+                this.SetAxis(axis1, axis2);
                 this.Rotation = newRotation * MathHelper.RadToDeg;
                 this.Normal = newNormal;
             }

--- a/CADability/netDxf/Entities/HatchGradientPattern.cs
+++ b/CADability/netDxf/Entities/HatchGradientPattern.cs
@@ -219,8 +219,7 @@ namespace netDxf.Entities
 
         private AciColor Color2FromTint(double value)
         {
-            double h, s, l;
-            AciColor.ToHsl(this.color1, out h, out s, out l);
+            AciColor.ToHsl(this.color1, out double h, out double s, out double _);
             return AciColor.FromHsl(h, s, value);
         }
 

--- a/CADability/netDxf/Entities/Image.cs
+++ b/CADability/netDxf/Entities/Image.cs
@@ -276,7 +276,7 @@ namespace netDxf.Entities
             get { return this.brightness; }
             set
             {
-                if (value < 0 && value > 100)
+                if (value < 0 || value > 100)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, "Accepted brightness values range from 0 to 100.");
                 }
@@ -292,7 +292,7 @@ namespace netDxf.Entities
             get { return this.contrast; }
             set
             {
-                if (value < 0 && value > 100)
+                if (value < 0 || value > 100)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, "Accepted contrast values range from 0 to 100.");
                 }
@@ -308,7 +308,7 @@ namespace netDxf.Entities
             get { return this.fade; }
             set
             {
-                if (value < 0 && value > 100)
+                if (value < 0 || value > 100)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value, "Accepted fade values range from 0 to 100.");
                 }

--- a/CADability/netDxf/Entities/Leader.cs
+++ b/CADability/netDxf/Entities/Leader.cs
@@ -801,7 +801,7 @@ namespace netDxf.Entities
 
                     position = hook + this.offset + Vector2.Rotate(textOffset, mText.Rotation * MathHelper.DegToRad);
 
-                    mText.Position = MathHelper.Transform(position, Normal, this.elevation);
+                    mText.Position = MathHelper.Transform(position, this.Normal, this.elevation);
                     mText.Height = textHeight * dimScale;
                     mText.Color = textColor.IsByBlock ? AciColor.ByLayer : textColor;
                     break;

--- a/CADability/netDxf/Entities/PolyfaceMesh.cs
+++ b/CADability/netDxf/Entities/PolyfaceMesh.cs
@@ -85,7 +85,7 @@ namespace netDxf.Entities
 
             if (faces == null)
             {
-                throw new ArgumentNullException(nameof(vertexes));
+                throw new ArgumentNullException(nameof(faces));
             }
 
             int numFaces = faces.Count();
@@ -125,7 +125,7 @@ namespace netDxf.Entities
 
             if (faces == null)
             {
-                throw new ArgumentNullException(nameof(vertexes));
+                throw new ArgumentNullException(nameof(faces));
             }
 
             this.faces = faces.ToArray();

--- a/CADability/netDxf/Header/HeaderVariables.cs
+++ b/CADability/netDxf/Header/HeaderVariables.cs
@@ -684,14 +684,7 @@ namespace netDxf.Header
         public UCS CurrentUCS
         {
             get { return this.currentUCS; } 
-            set
-            {
-                if (value == null)
-                {
-                    throw new ArgumentNullException(nameof(value));
-                }
-                this.currentUCS = value;
-            } 
+            set { this.currentUCS = value ?? throw new ArgumentNullException(nameof(value)); } 
         }
 
         #endregion

--- a/CADability/netDxf/IO/EncodingType.cs
+++ b/CADability/netDxf/IO/EncodingType.cs
@@ -40,26 +40,33 @@ namespace netDxf.IO
             Encoding reVal = Encoding.ASCII; //.Default;
 
             BinaryReader r = new BinaryReader(fs, Encoding.Default);
-            int i;
-            if (!int.TryParse(fs.Length.ToString(CultureInfo.InvariantCulture), out i))
+            if (!int.TryParse(fs.Length.ToString(CultureInfo.InvariantCulture), out int i))
+            {
                 return null;
+            }
 
             byte[] ss = r.ReadBytes(i);
             if (IsUTF8Bytes(ss) || (ss[0] == utf8[0] && ss[1] == utf8[1] && ss[2] == utf8[2]))
+            {
                 reVal = Encoding.UTF8;
+            }
             else if (ss[0] == unicodeBig[0] && ss[1] == unicodeBig[1] && ss[2] == unicodeBig[2])
+            {
                 reVal = Encoding.BigEndianUnicode;
+            }
             else if (ss[0] == unicode[0] && ss[1] == unicode[1] && ss[2] == unicode[2])
+            {
                 reVal = Encoding.Unicode;
+            }
             return reVal;
         }
 
         private static bool IsUTF8Bytes(byte[] data)
         {
             int charByteCounter = 1;
-            for (int i = 0; i < data.Length; i++)
+            foreach (byte t in data)
             {
-                byte curByte = data[i];
+                byte curByte = t;
                 if (charByteCounter == 1)
                 {
                     if (curByte >= 0x80)
@@ -74,12 +81,17 @@ namespace netDxf.IO
                 else
                 {
                     if ((curByte & 0xC0) != 0x80)
+                    {
                         return false;
+                    }
                     charByteCounter--;
                 }
             }
+
             if (charByteCounter > 1)
+            {
                 throw new Exception("Error byte format.");
+            }
 
             return true;
         }

--- a/CADability/netDxf/MathHelper.cs
+++ b/CADability/netDxf/MathHelper.cs
@@ -397,8 +397,8 @@ namespace netDxf
         {
             Matrix3 trans = ArbitraryAxis(zAxis).Transpose();
             Vector3 p = trans * point;
-            elevation = point.Z;
-            return new Vector2(point.X, point.Y);
+            elevation = p.Z;
+            return new Vector2(p.X, p.Y);
         }
 
         /// <summary>

--- a/CADability/netDxf/Matrix4.cs
+++ b/CADability/netDxf/Matrix4.cs
@@ -969,36 +969,36 @@ namespace netDxf
                                0.0, 0.0, z, 0.0,
                                0.0, 0.0, 0.0, 1.0);
         }
-		
-		/// <summary>
-		/// Build a translation matrix.
-		/// </summary>
-		/// <param name="vector">Translation vector along the X, Y, and Z axis.</param>
-		/// <returns>A translation matrix.</returns>
-		/// <remarks>Matrix4 adopts the convention of using column vectors to represent a transformation matrix.</remarks>
-		public static Matrix4 Translation(Vector3 vector)
-		{
-			return new Matrix4(1.0, 0.0, 0.0, vector.X,
+        
+        /// <summary>
+        /// Build a translation matrix.
+        /// </summary>
+        /// <param name="vector">Translation vector along the X, Y, and Z axis.</param>
+        /// <returns>A translation matrix.</returns>
+        /// <remarks>Matrix4 adopts the convention of using column vectors to represent a transformation matrix.</remarks>
+        public static Matrix4 Translation(Vector3 vector)
+        {
+            return new Matrix4(1.0, 0.0, 0.0, vector.X,
                                0.0, 1.0, 0.0, vector.Y,
                                0.0, 0.0, 1.0, vector.Z,
                                0.0, 0.0, 0.0, 1.0);
-		}
-		
-		/// <summary>
-		/// Build a translation matrix.
-		/// </summary>
-		/// <param name="x">Translation along the X axis.</param>
-		/// <param name="y">Translation along the Y axis.</param>
-		/// <param name="z">Translation along the Z axis.</param>
-		/// <returns>A translation matrix.</returns>
-		/// <remarks>Matrix4 adopts the convention of using column vectors to represent a transformation matrix.</remarks>
-		public static Matrix4 Translation(double x, double y, double z)
-		{
-			return new Matrix4(1.0, 0.0, 0.0, x,
+        }
+        
+        /// <summary>
+        /// Build a translation matrix.
+        /// </summary>
+        /// <param name="x">Translation along the X axis.</param>
+        /// <param name="y">Translation along the Y axis.</param>
+        /// <param name="z">Translation along the Z axis.</param>
+        /// <returns>A translation matrix.</returns>
+        /// <remarks>Matrix4 adopts the convention of using column vectors to represent a transformation matrix.</remarks>
+        public static Matrix4 Translation(double x, double y, double z)
+        {
+            return new Matrix4(1.0, 0.0, 0.0, x,
                                0.0, 1.0, 0.0, y,
                                0.0, 0.0, 1.0, z,
                                0.0, 0.0, 0.0, 1.0);
-		}
+        }
 
         /// <summary>
         /// Build the reflection matrix of a mirror plane that passes through a point.

--- a/CADability/netDxf/Objects/PlotSettings.cs
+++ b/CADability/netDxf/Objects/PlotSettings.cs
@@ -313,9 +313,9 @@ namespace netDxf.Objects
             get { return this.shadePlotDPI; }
             set
             {
-                if (value < 100 || value > 32767)
+                if (value < 100)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, "The valid shade plot DPI values range from 100 to 23767.");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The valid shade plot DPI values range from 100 to the maximum value allowed by the plot device.");
                 }
                 this.shadePlotDPI = value;
             }

--- a/CADability/netDxf/Objects/UnderlayPdfDefinition.cs
+++ b/CADability/netDxf/Objects/UnderlayPdfDefinition.cs
@@ -23,7 +23,6 @@
 // 
 #endregion
 
-using System;
 using System.IO;
 using netDxf.Collections;
 using netDxf.Tables;

--- a/CADability/netDxf/Tables/DimensionStyle.cs
+++ b/CADability/netDxf/Tables/DimensionStyle.cs
@@ -775,7 +775,7 @@ namespace netDxf.Tables
         }
 
         /// <summary>
-        /// Gets or sets the positioning of the dimension text inside extension lines. (DIMTIH)
+        /// Gets or sets if the dimension text is placed horizontally when inside extension lines. (DIMTIH)
         /// </summary>
         /// <remarks>
         /// Default: false
@@ -787,7 +787,7 @@ namespace netDxf.Tables
         }
 
         /// <summary>
-        /// Gets or sets the positioning of the dimension text outside extension lines. (DIMTOH)
+        /// Gets or sets if the dimension text is placed horizontally when outside extension lines. (DIMTOH)
         /// </summary>
         /// <remarks>
         /// Default: false

--- a/CADability/netDxf/Tables/DimensionStyleOverride.cs
+++ b/CADability/netDxf/Tables/DimensionStyleOverride.cs
@@ -1,4 +1,5 @@
 #region netDxf library licensed under the MIT License
+
 // 
 //                       netDxf library
 // Copyright (c) 2019-2021 Daniel Carvajal (haplokuon@gmail.com)
@@ -21,6 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 // 
+
 #endregion
 
 using System;
@@ -48,367 +50,671 @@ namespace netDxf.Tables
             {
                 case DimensionStyleOverrideType.DimLineColor:
                     if (!(value is AciColor))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (AciColor)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(AciColor)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimLineLinetype:
                     if (!(value is Linetype))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Linetype)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Linetype)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimLineLineweight:
                     if (!(value is Lineweight))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Lineweight)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Lineweight)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimLine1Off:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimLine2Off:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimLineExtend:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value < 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLineColor:
                     if (!(value is AciColor))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (AciColor)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(AciColor)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLine1Linetype:
                     if (!(value is Linetype))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Linetype)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Linetype)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLine2Linetype:
                     if (!(value is Linetype))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Linetype)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Linetype)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLineLineweight:
                     if (!(value is Lineweight))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Lineweight)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Lineweight)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLine1Off:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLine2Off:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLineOffset:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value < 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLineExtend:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value < 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLineFixed:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ExtLineFixedLength:
                     if (!(value is double))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     if ((double)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.ArrowSize:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value < 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.CenterMarkSize:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.LeaderArrow:
                     if (value == null)
+                    {
                         break;
+                    }
+
                     if (!(value is Block))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Block)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Block)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimArrow1:
                     if (value == null)
+                    {
                         break;
+                    }
+
                     if (!(value is Block))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Block)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Block)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimArrow2:
                     if (value == null)
+                    {
                         break;
+                    }
+
                     if (!(value is Block))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (Block)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(Block)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextStyle:
                     if (!(value is TextStyle))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (TextStyle)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(TextStyle)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextColor:
                     if (!(value is AciColor))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (AciColor)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(AciColor)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextFillColor:
                     if (value == null)
+                    {
                         break;
+                    }
+
                     if (!(value is AciColor))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(AciColor)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextHeight:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value <= 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value <= 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextOffset:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextVerticalPlacement:
                     if (!(value is DimensionStyleTextVerticalPlacement))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(DimensionStyleTextVerticalPlacement)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextHorizontalPlacement:
                     if (!(value is DimensionStyleTextHorizontalPlacement))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(DimensionStyleTextHorizontalPlacement)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextInsideAlign:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextOutsideAlign:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextDirection:
                     if (!(value is DimensionStyleTextDirection))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(DimensionStyleTextDirection)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TextFractionHeightScale:
                     if (!(value is double))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     if ((double)value <= 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.FitDimLineForce:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.FitDimLineInside:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimScaleOverall:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value < 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.FitOptions:
                     if (!(value is DimensionStyleFitOptions))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(DimensionStyleFitOptions)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.FitTextInside:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.FitTextMove:
                     if (!(value is DimensionStyleFitTextMove))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(DimensionStyleFitTextMove)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AngularPrecision:
                     if (!(value is short))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (short)), nameof(value));
-                    if ((short) value < -1)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(short)), nameof(value));
+                    }
+
+                    if ((short)value < -1)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be greater than -1.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.LengthPrecision:
                     if (!(value is short))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (short)), nameof(value));
-                    if ((short) value < 0)
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(short)), nameof(value));
+                    }
+
+                    if ((short)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimPrefix:
                     if (!(value is string))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (string)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(string)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimSuffix:
                     if (!(value is string))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (string)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(string)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DecimalSeparator:
                     if (!(value is char))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (char)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(char)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimScaleLinear:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if (MathHelper.IsZero((double) value))
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if (MathHelper.IsZero((double)value))
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The DimensionStyleOverrideType.{0} dimension style override cannot be zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimLengthUnits:
                     if (!(value is LinearUnitType))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (LinearUnitType)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(LinearUnitType)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimAngularUnits:
                     if (!(value is AngleUnitType))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (AngleUnitType)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(AngleUnitType)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.FractionalType:
                     if (!(value is FractionFormatType))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (FractionFormatType)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(FractionFormatType)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.SuppressLinearLeadingZeros:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.SuppressLinearTrailingZeros:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.SuppressAngularLeadingZeros:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.SuppressAngularTrailingZeros:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.SuppressZeroFeet:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.SuppressZeroInches:
                     if (!(value is bool))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (bool)), nameof(value));
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.DimRoundoff:
                     if (!(value is double))
-                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof (double)), nameof(value));
-                    if ((double) value < 0.000001 && !MathHelper.IsZero((double)value, double.Epsilon))
+                    {
+                        throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
+                    if ((double)value < 0.000001 && !MathHelper.IsZero((double)value, double.Epsilon))
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be equals or greater than 0.000001 or zero (no rounding off).", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsEnabled:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsLengthUnits:
                     if (!(value is LinearUnitType))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(LinearUnitType)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsStackedUnits:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsLengthPrecision:
                     if (!(value is short))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(short)), nameof(value));
+                    }
+
                     if ((short)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsMultiplier:
                     if (!(value is double))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     if ((double)value <= 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsRoundoff:
                     if (!(value is double))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     if ((double)value < 0.000001 && !MathHelper.IsZero((double)value, double.Epsilon))
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be equals or greater than 0.000001 or zero (no rounding off).", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsPrefix:
                     if (!(value is string))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(string)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsSuffix:
                     if (!(value is string))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(string)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsSuppressLinearLeadingZeros:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsSuppressLinearTrailingZeros:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsSuppressZeroFeet:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.AltUnitsSuppressZeroInches:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesDisplayMethod:
                     if (!(value is DimensionStyleTolerancesDisplayMethod))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(LinearUnitType)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesUpperLimit:
                     if (!(value is double))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesLowerLimit:
                     if (!(value is double))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(double)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesVerticalPlacement:
                     if (!(value is DimensionStyleTolerancesVerticalPlacement))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(LinearUnitType)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesPrecision:
                     if (!(value is short))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(short)), nameof(value));
+                    }
+
                     if ((short)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesSuppressLinearLeadingZeros:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesSuppressLinearTrailingZeros:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesSuppressZeroFeet:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesSuppressZeroInches:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesAlternatePrecision:
                     if (!(value is short))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(short)), nameof(value));
+                    }
+
                     if ((short)value < 0)
+                    {
                         throw new ArgumentOutOfRangeException(nameof(value), value, string.Format("The {0} dimension style override must be equals or greater than zero.", type));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesAltSuppressLinearLeadingZeros:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesAltSuppressLinearTrailingZeros:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesAltSuppressZeroFeet:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
                 case DimensionStyleOverrideType.TolerancesAltSuppressZeroInches:
                     if (!(value is bool))
+                    {
                         throw new ArgumentException(string.Format("The DimensionStyleOverrideType.{0} dimension style override must be a valid {1}", type, typeof(bool)), nameof(value));
+                    }
+
                     break;
             }
+
             this.type = type;
             this.value = value;
         }

--- a/CADability/netDxf/netDxf.csproj
+++ b/CADability/netDxf/netDxf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <Version>3.0.0</Version>
     <Authors>Daniel Carvajal</Authors>
     <Owners>haplokuon</Owners>
@@ -19,11 +19,15 @@
     <PackageReleaseNotes>netDxf is a .net library programmed in C# to read and write AutoCAD DXF files. It supports AutoCad2000, AutoCad2004, AutoCad2007, AutoCad2010, AutoCad2013, and AutoCad2018 DXF database versions, in both text and binary format.</PackageReleaseNotes>
     <PackageTags>netDxf, Dxf, Dxf reader, Dxf writer, AutoCad</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Title>netDxf</Title>
+    <RunAnalyzersDuringLiveAnalysis>false</RunAnalyzersDuringLiveAnalysis>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DocumentationFile>netDxf.xml</DocumentationFile>
-    <NoWarn>1701;1702;1591</NoWarn>
+    <NoWarn>1701;1702</NoWarn>
     <OutputPath></OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
@@ -32,14 +36,15 @@
     <DocumentationFile>netDxf.xml</DocumentationFile>
     <DebugType>none</DebugType>
     <DebugSymbols>false</DebugSymbols>
-    <OutputPath></OutputPath>
     <NoWarn>1701;1702</NoWarn>
+    <OutputPath></OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
     <DefineConstants>NET45</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>

--- a/CADability/netDxf/netDxf.xml
+++ b/CADability/netDxf/netDxf.xml
@@ -593,6 +593,11 @@
             Additionally Paper Space blocks do not contain attribute definitions.
             </remarks>
         </member>
+        <member name="P:netDxf.Blocks.Block.Owner">
+            <summary>
+            Gets the owner of the actual DXF object.
+            </summary>
+        </member>
         <member name="P:netDxf.Blocks.Block.Record">
             <summary>
             Gets the block record associated with this block.
@@ -5399,7 +5404,11 @@
             <param name="center">Ellipse <see cref="T:netDxf.Vector2">center</see> in object coordinates.</param>
             <param name="majorAxis">Ellipse major axis.</param>
             <param name="minorAxis">Ellipse minor axis.</param>
-            <remarks>The center Z coordinate represents the elevation of the arc along the normal.</remarks>
+            <remarks>
+            The center Z coordinate represents the elevation of the ellipse along the normal.
+            The major axis is always measured along the ellipse local X axis,
+            while the minor axis is along the local Y axis.
+            </remarks>
         </member>
         <member name="M:netDxf.Entities.Ellipse.#ctor(netDxf.Vector3,System.Double,System.Double)">
             <summary>
@@ -5408,7 +5417,11 @@
             <param name="center">Ellipse <see cref="T:netDxf.Vector3">center</see> in object coordinates.</param>
             <param name="majorAxis">Ellipse major axis.</param>
             <param name="minorAxis">Ellipse minor axis.</param>
-            <remarks>The center Z coordinate represents the elevation of the arc along the normal.</remarks>
+            <remarks>
+            The center Z coordinate represents the elevation of the ellipse along the normal.
+            The major axis is always measured along the ellipse local X axis,
+            while the minor axis is along the local Y axis.
+            </remarks>
         </member>
         <member name="P:netDxf.Entities.Ellipse.Center">
             <summary>
@@ -5419,13 +5432,13 @@
             <summary>
             Gets or sets the ellipse mayor axis.
             </summary>
-            <remarks>The MajorAxis value must be positive and greater than the MinorAxis.</remarks>
+            <remarks>The major axis is always measured along the ellipse local X axis.</remarks>
         </member>
         <member name="P:netDxf.Entities.Ellipse.MinorAxis">
             <summary>
             Gets or sets the ellipse minor axis.
             </summary>
-            <remarks>The MinorAxis value must be positive and smaller than the MajorAxis.</remarks>
+            <remarks>The minor axis is always measured along the ellipse local Y axis.</remarks>
         </member>
         <member name="P:netDxf.Entities.Ellipse.Rotation">
             <summary>
@@ -5457,10 +5470,13 @@
         </member>
         <member name="M:netDxf.Entities.Ellipse.SetAxis(System.Double,System.Double)">
             <summary>
-            Sets the ellipse major and minor axis.
+            Sets the ellipse major and minor axis from the two parameters.
             </summary>
-            <param name="major">Ellipse major axis.</param>
-            <param name="minor">Ellipse minor axis.</param>
+            <param name="axis1">Ellipse axis.</param>
+            <param name="axis2">Ellipse axis.</param>
+            <remarks>
+            It is not required that axis1 is greater than axis2. The larger value will be assigned as major axis and the lower as minor axis.
+            </remarks>
         </member>
         <member name="M:netDxf.Entities.Ellipse.PolarCoordinateRelativeToCenter(System.Double)">
             <summary>
@@ -13915,51 +13931,6 @@
             </para>
             </remarks>
         </member>
-        <member name="M:netDxf.Objects.ImageDefinition.#ctor(System.String)">
-             <summary>
-             Initializes a new instance of the <c>ImageDefinition</c> class. Only available for Net Framework 4.5 builds.
-             </summary>
-             <param name="file">Image file name with full or relative path.</param>
-            <remarks>
-             <para>
-             The name of the file without extension will be used as the name of the image definition.
-             </para>
-             <para>
-             Supported image formats: BMP, JPG, PNG, TIFF.<br />
-             Even thought AutoCAD supports more image formats, this constructor is restricted to the ones the net framework supports in common with AutoCAD.
-             Use the generic constructor instead.
-             </para>
-             <para>
-             Note (this is from the ACAD docs): AutoCAD 2000, AutoCAD LT 2000, and later releases do not support LZW-compressed TIFF files,
-             with the exception of English language versions sold in the US and Canada.<br />
-             If you have TIFF files that were created using LZW compression and want to insert them into a drawing 
-             you must save the TIFF files with LZW compression disabled.
-             </para>
-            </remarks>
-        </member>
-        <member name="M:netDxf.Objects.ImageDefinition.#ctor(System.String,System.String)">
-             <summary>
-             Initializes a new instance of the <c>ImageDefinition</c> class. Only available for Net Framework 4.5 builds.
-             </summary>
-            <param name="name">Image definition name.</param>
-            <param name="file">Image file name with full or relative path.</param>
-            <remarks>
-             <para>
-             The name assigned to the image definition must be unique.
-             </para>
-             <para>
-             Supported image formats: BMP, JPG, PNG, TIFF.<br />
-             Even thought AutoCAD supports more image formats, this constructor is restricted to the ones the .net library supports in common with AutoCAD.
-             Use the generic constructor instead.
-             </para>
-             <para>
-             Note (this is from the ACAD docs): AutoCAD 2000, AutoCAD LT 2000, and later releases do not support LZW-compressed TIFF files,
-             with the exception of English language versions sold in the US and Canada.<br />
-             If you have TIFF files that were created using LZW compression and want to insert them into a drawing 
-             you must save the TIFF files with LZW compression disabled.
-             </para>
-            </remarks>
-        </member>
         <member name="P:netDxf.Objects.ImageDefinition.File">
             <summary>
             Gets or sets the image file.
@@ -15741,7 +15712,7 @@
         </member>
         <member name="P:netDxf.Tables.DimensionStyle.TextInsideAlign">
             <summary>
-            Gets or sets the positioning of the dimension text inside extension lines. (DIMTIH)
+            Gets or sets if the dimension text is placed horizontally when inside extension lines. (DIMTIH)
             </summary>
             <remarks>
             Default: false
@@ -15749,7 +15720,7 @@
         </member>
         <member name="P:netDxf.Tables.DimensionStyle.TextOutsideAlign">
             <summary>
-            Gets or sets the positioning of the dimension text outside extension lines. (DIMTOH)
+            Gets or sets if the dimension text is placed horizontally when outside extension lines. (DIMTOH)
             </summary>
             <remarks>
             Default: false
@@ -17808,14 +17779,6 @@
             <summary>
             Gets the owner of the actual text style.
             </summary>
-        </member>
-        <member name="M:netDxf.Tables.TextStyle.TrueTypeFontFamilyName(System.String)">
-            <summary>
-            Find the font family name of an specified TTF font file. Only available for Net Framework 4.5 builds.
-            </summary>
-            <param name="ttfFont">TTF font file.</param>
-            <returns>The font family name of the specified TTF font file.</returns>
-            <remarks>This method will return an empty string if the specified font is not found in its path or the system font folder or if it is not a valid TTF font.</remarks>
         </member>
         <member name="M:netDxf.Tables.TextStyle.Clone(System.String)">
             <summary>


### PR DESCRIPTION
Change log from netDXF:
 [2022/11/01]

* Workaround for bad DXF files that contain polyface with invalid geometry, they will be removed.
* Workaround for bad DXF files that contains entities without handles. This may derive in unexpected side effects.
* Workaround for bad DXF files lacking BLOCK_RECORD tables for the defined blocks. The default block record values will be given what may have other side effects.
* Workaround for possible duplicate layers in layer states properties when reading a DXF.
* The Ellipse SetAxis method will automatically assign the larger axis value as the major axis and the lower as the minor axis.
* Added NET 6.0 as a target framework.
* Updated netDxf solution for Visual Studio 2022. The solution file is still usable by Visual Studio 2019 but it does not support NET 6.0.