### PR TITLE
Ignore invalid tolerance string

### DIFF
--- a/CADability/netDxf/Entities/Tolerance.cs
+++ b/CADability/netDxf/Entities/Tolerance.cs
@@ -539,8 +539,10 @@ namespace netDxf.Entities
                     case 5:
                         d3 = ParseDatumReferenceValue(value);
                         break;
-                    default:
-                        throw new FormatException("The tolerance string representation is not well formatted");
+                        //FIXME: The error was removed on the advise by haplokuon and will probably be fixed in one of the next versions
+                        //see here https://github.com/haplokuon/netDxf/issues/426
+                        //default:
+                        //    throw new FormatException("The tolerance string representation is not well formatted");
                 }
             }
 


### PR DESCRIPTION
FormatException could be raised if an invalid Tolerance String was passed.
It's safe to ignore this error for now.

See: #https://github.com/haplokuon/netDxf/issues/426
