### PR TITLE
Alternative import and export method: ByteArray instead of file name

### DIFF
--- a/CADability/ExportDxf.cs
+++ b/CADability/ExportDxf.cs
@@ -24,6 +24,25 @@ namespace CADability.DXF
             createdLayers = new Dictionary<Attribute.Layer, netDxf.Tables.Layer>();
             createdLinePatterns = new Dictionary<LinePattern, Linetype>();
         }
+        public byte[] WriteToByteArray(Project toExport)
+        {
+            var memoryStream = new System.IO.MemoryStream();
+            Model modelSpace = null;
+            if (toExport.GetModelCount() == 1) modelSpace = toExport.GetModel(0);
+            else
+            {
+                modelSpace = toExport.FindModel("*Model_Space");
+            }
+            if (modelSpace == null) modelSpace = toExport.GetActiveModel();
+            for (int i = 0; i < modelSpace.Count; i++)
+            {
+                EntityObject entity = GeoObjectToEntity(modelSpace[i]);
+                if (entity != null) doc.Entities.Add(entity);
+            }
+            doc.Save(memoryStream);
+            return memoryStream.ToArray();
+        }
+
         public void WriteToFile(Project toExport, string filename)
         {
             Model modelSpace = null;

--- a/CADability/ExportStep.cs
+++ b/CADability/ExportStep.cs
@@ -85,6 +85,54 @@ END-ISO-10303-21;"; // %0: filename, %1: date, %2: version, %3: List of MANIFOLD
             StyledItems = new Dictionary<ColorDef, int>();
             Precision = 1e-6;
         }
+
+        public byte[] WriteToByteArray(Project pr)
+        {
+            var memoryStream = new MemoryStream();
+            stream = new StreamWriter(memoryStream);
+            stream.WriteLine(header.Replace("%0", pr.FileName).Replace("%1", DateTime.Now.ToString("O")));
+            currentItem = 25;
+            StringBuilder lst = new StringBuilder();
+            int mainAxis = WriteAxis2Placement3d(GeoPoint.Origin, GeoVector.ZAxis, GeoVector.XAxis);
+            List<int> representationItems = new List<int>();
+            foreach (IGeoObject go in pr.GetActiveModel())
+            {
+                if (go is IExportStep)
+                {
+                    int n = (go as IExportStep).Export(this, true);
+                    if (lst.Length == 0) lst.Append("#" + n.ToString());
+                    else lst.Append(",#" + n.ToString());
+
+                    int axis = WriteAxis2Placement3d(GeoPoint.Origin, GeoVector.ZAxis, GeoVector.XAxis);
+                    int repMap = WriteDefinition("REPRESENTATION_MAP(#" + mainAxis.ToString() + ",#" + n.ToString() + ")");
+                    int mappedItem = WriteDefinition("MAPPED_ITEM( '', #" + repMap.ToString() + ",#" + axis.ToString() + ")");
+                    representationItems.Add(mappedItem);
+
+                }
+            }
+            representationItems.Add(mainAxis);
+            string Name = pr.FileName;
+            Name = "";
+            int sr = WriteDefinition("SHAPE_REPRESENTATION('" + Name + "',(" + ToString(representationItems.ToArray(), true) + "),#4)");
+            int product = WriteDefinition("PRODUCT( '" + Name + "','" + Name + "','',(#2))");
+            int pdf = WriteDefinition("PRODUCT_DEFINITION_FORMATION_WITH_SPECIFIED_SOURCE( ' ', 'NONE', #" + product.ToString() + ", .NOT_KNOWN. )");
+            int pd = WriteDefinition("PRODUCT_DEFINITION( 'NONE', 'NONE', #" + pdf.ToString() + ", #3 )");
+            int pds = WriteDefinition("PRODUCT_DEFINITION_SHAPE( 'NONE', 'NONE', #" + pd.ToString() + " )");
+            WriteDefinition("SHAPE_DEFINITION_REPRESENTATION( #" + pds.ToString() + ", #" + sr.ToString() + ")");
+
+            StringBuilder ssi = new StringBuilder();
+            foreach (int item in StyledItems.Values)
+            {
+                if (ssi.Length == 0) ssi.Append("#");
+                else ssi.Append(",#");
+                ssi.Append(item.ToString());
+            }
+            stream.WriteLine(footer); //.Replace("%3", lst.ToString()).Replace("%5", ssi.ToString()));
+            stream.Close();
+
+            return memoryStream.ToArray();
+        }
+
         public void WriteToFile(string fileName, Project pr)
         {
 

--- a/CADability/ImportSTL.cs
+++ b/CADability/ImportSTL.cs
@@ -120,13 +120,13 @@ namespace CADability
             while (!allFaces.IsEmpty())
             {
                 Shell part = Shell.CollectConnected(allFaces);
-//#if DEBUG
-//                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
-//                double precision;
-//                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
-//                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
-//                part.ReconstructSurfaces(precision);
-//#endif
+#if DEBUG
+                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
+                double precision;
+                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
+                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
+                part.ReconstructSurfaces(precision);
+#endif
                 res.Add(part);
             }
             return res.ToArray();

--- a/CADability/ImportSTL.cs
+++ b/CADability/ImportSTL.cs
@@ -213,13 +213,13 @@ namespace CADability
             while (!allFaces.IsEmpty())
             {
                 Shell part = Shell.CollectConnected(allFaces);
-                //#if DEBUG
-                //                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
-                //                double precision;
-                //                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
-                //                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
-                //                part.ReconstructSurfaces(precision);
-                //#endif
+#if DEBUG
+                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
+                double precision;
+                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
+                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
+                part.ReconstructSurfaces(precision);
+#endif
                 res.Add(part);
             }
             return res.ToArray();

--- a/CADability/ImportSTL.cs
+++ b/CADability/ImportSTL.cs
@@ -120,13 +120,106 @@ namespace CADability
             while (!allFaces.IsEmpty())
             {
                 Shell part = Shell.CollectConnected(allFaces);
-#if DEBUG
-                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
-                double precision;
-                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
-                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
-                part.ReconstructSurfaces(precision);
-#endif
+//#if DEBUG
+//                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
+//                double precision;
+//                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
+//                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
+//                part.ReconstructSurfaces(precision);
+//#endif
+                res.Add(part);
+            }
+            return res.ToArray();
+        }
+
+
+        public Shell[] Read(byte[] byteArray)
+        {
+            List<Shell> res = new List<Shell>();
+
+            using (sr = new StreamReader(new MemoryStream(byteArray))) // may throw exceptions like "file not found" etc.
+            {
+                char[] head = new char[5];
+                int read = sr.ReadBlock(head, 0, 5);
+                if (read != 5) throw new ApplicationException("cannot read from file");
+                if (new string(head) == "solid") isASCII = true;
+                else isASCII = false;
+            }
+            if (isASCII)
+            {
+                sr = new StreamReader(new MemoryStream(byteArray));
+                string title = sr.ReadLine();
+            }
+            else
+            {
+                br = new BinaryReader(new MemoryStream(byteArray));
+                br.ReadBytes(80);
+                uint nrtr = br.ReadUInt32();
+            }
+            OctTree<Vertex> verticesOctTree = null;
+            triangle tr;
+            int cnt = 0;
+            Set<Face> allFaces = new Set<Face>();
+            GeoObjectList dbgl = new GeoObjectList();
+            do
+            {
+                tr = GetNextTriangle();
+                if (tr == null) break;
+                if (verticesOctTree == null) verticesOctTree = new OctTree<Vertex>(new BoundingCube(tr.p1, tr.p2, tr.p3), 1e-6);
+                try
+                {
+                    PlaneSurface ps = new PlaneSurface(tr.p1, tr.p2, tr.p3);
+                    Vertex v1 = VertexFromPoint(verticesOctTree, tr.p1);
+                    Vertex v2 = VertexFromPoint(verticesOctTree, tr.p2);
+                    Vertex v3 = VertexFromPoint(verticesOctTree, tr.p3);
+                    Edge e1 = Vertex.SingleConnectingEdge(v1, v2);
+                    if (e1 != null && e1.SecondaryFace != null)
+                    { }
+                    if (e1 == null || e1.SecondaryFace != null) e1 = new Edge(Line.TwoPoints(v1.Position, v2.Position), v1, v2);
+                    Edge e2 = Vertex.SingleConnectingEdge(v2, v3);
+                    if (e2 != null && e2.SecondaryFace != null)
+                    { }
+                    if (e2 == null || e2.SecondaryFace != null) e2 = new Edge(Line.TwoPoints(v2.Position, v3.Position), v2, v3);
+                    Edge e3 = Vertex.SingleConnectingEdge(v3, v1);
+                    if (e3 != null && e3.SecondaryFace != null)
+                    { }
+                    if (e3 == null || e3.SecondaryFace != null) e3 = new Edge(Line.TwoPoints(v3.Position, v1.Position), v3, v1);
+                    dbgl.Add(Line.TwoPoints(v1.Position, v2.Position));
+                    dbgl.Add(Line.TwoPoints(v2.Position, v3.Position));
+                    dbgl.Add(Line.TwoPoints(v3.Position, v1.Position));
+                    Face fc = Face.Construct();
+                    fc.Surface = ps;
+                    //Line2D l1 = new Line2D(ps.Plane.Project(tr.p1), ps.Plane.Project(tr.p2));
+                    //Line2D l2 = new Line2D(ps.Plane.Project(tr.p2), ps.Plane.Project(tr.p3));
+                    //Line2D l3 = new Line2D(ps.Plane.Project(tr.p3), ps.Plane.Project(tr.p1));
+                    //if (e1.PrimaryFace == null) e1.SetPrimary(fc, l1, true);
+                    //else e1.SetSecondary(fc, l1, false);
+                    //if (e2.PrimaryFace == null) e2.SetPrimary(fc, l2, true);
+                    //else e2.SetSecondary(fc, l2, false);
+                    //if (e3.PrimaryFace == null) e3.SetPrimary(fc, l3, true);
+                    //else e3.SetSecondary(fc, l3, false);
+                    e1.SetFace(fc, e1.Vertex1 == v1);
+                    e2.SetFace(fc, e2.Vertex1 == v2);
+                    e3.SetFace(fc, e3.Vertex1 == v3);
+                    fc.Set(ps, new Edge[][] { new Edge[] { e1, e2, e3 } });
+                    allFaces.Add(fc);
+                    ++cnt;
+                }
+                catch (ModOpException)
+                {
+                    // empty triangle, plane construction failed
+                }
+            } while (tr != null);
+            while (!allFaces.IsEmpty())
+            {
+                Shell part = Shell.CollectConnected(allFaces);
+                //#if DEBUG
+                //                // TODO: some mechanism to tell whether and how to reverse engineer the stl file
+                //                double precision;
+                //                if (numnum == 0) precision = part.GetExtent(0.0).Size * 1e-5;
+                //                else precision = Math.Pow(10, -numdec / (double)(numnum)); // numdec/numnum is average number of decimal places
+                //                part.ReconstructSurfaces(precision);
+                //#endif
                 res.Add(part);
             }
             return res.ToArray();


### PR DESCRIPTION
For being able to import and export files in a browser (WASM) project, I added some (redundant) code to read and write byte arrays. Feel free to use, edit or cancel the pull request.