### PR TITLE
Add capability to modify the common length property of selected objects

### DIFF
--- a/CADability.Forms/CADability.Forms.csproj
+++ b/CADability.Forms/CADability.Forms.csproj
@@ -150,7 +150,6 @@
     <Compile Include="CadCanvas.cs">
       <SubType>Component</SubType>
     </Compile>
-    <Compile Include="ImportSVG.cs" />
     <Compile Include="MenuManager.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/CADability/SelectedObjectsProperty.cs
+++ b/CADability/SelectedObjectsProperty.cs
@@ -133,6 +133,7 @@ namespace CADability.UserInterface
                     {
                         //LengthProperty e.g. Radius, Diameter, arc length
                         case LengthProperty lp:
+                            if (lp.ReadOnly) continue; //Only add writeable properties
                             LengthProperty commonPropLength = new LengthProperty(frame, prop.ResourceId);
                             commonPropLength.OnSetValue = delegate (double l) { CommonProp_SetLengthEvent(commonPropLength.ResourceId, l); };
                             commonPropLength.OnGetValue = delegate () { return CommonProp_GetLengthEvent(commonPropLength.ResourceId); };


### PR DESCRIPTION
With these changes it's now possible to change the Length Property of objects that are the same type.
e.g. you can now change the radius if all selected objects are circles.

![grafik](https://github.com/SOFAgh/CADability/assets/45662116/a45e6203-1e50-41cf-b4f0-6702f8046a19)

Open questions:
- Should we limit this to the same object types only?
- Does it affect performance?
- What other common properties except Length Property could be needed?