### PR TITLE
Properties explorer refresh bug

### DIFF
--- a/CADability.Forms/PropertiesExplorer.cs
+++ b/CADability.Forms/PropertiesExplorer.cs
@@ -365,7 +365,16 @@ namespace CADability.Forms
                     if (EntryWithTextBox == toRefresh) // this was necessary because it might be called after the textBox entry had changed
                     {
                         bool allSelected = textBox.SelectionLength == textBox.Text.Length;
-                        textBox.Text = toRefresh.Value;
+                        //Save caret position here. If the textBox.Text property is set, the caret will be moved to the first position.
+                        //e.g. If you input text into the LengthProperty the cursor will always move to the first position
+                        int caretPos = textBox.SelectionStart;
+                        if (textBox.Text != toRefresh.Value)
+                        {
+                            textBox.Text = toRefresh.Value;
+                            //Restore last position
+                            textBox.SelectionStart = caretPos;
+                        }
+
                         textBox.Modified = false;
                         if (allSelected) textBox.SelectAll();
                         textBox.Update(); // to show smooth updating of the text when the mouse is moving

--- a/CADability/ImportDxf.cs
+++ b/CADability/ImportDxf.cs
@@ -19,6 +19,7 @@ using netDxf.Tables;
 using System.Text;
 using System.IO;
 using System.Diagnostics;
+using Polyline2D = netDxf.Entities.Polyline2D;
 
 namespace CADability.DXF
 {
@@ -471,6 +472,12 @@ namespace CADability.DXF
                 {
                     poles[i] = GeoPoint(spline.ControlPoints[i]);
                     weights[i] = spline.Weights[i];
+
+                    if (i > 0 && (poles[i] | poles[i - 1]) < Precision.eps)
+                    {
+                        var p2d = spline.ToPolyline2D(spline.ControlPoints.Length + spline.Knots.Length + 1);
+                        return CreatePolyline2D(p2d);
+                    }
                 }
                 double[] kn = new double[spline.Knots.Length];
                 for (int i = 0; i < kn.Length; ++i)

--- a/CADability/ImportDxf.cs
+++ b/CADability/ImportDxf.cs
@@ -2,9 +2,7 @@
 using System.Collections.Generic;
 using netDxf;
 using netDxf.Entities;
-using netDxf.Blocks;
 using CADability.GeoObject;
-using System.Runtime.CompilerServices;
 using CADability.Shapes;
 using CADability.Curve2D;
 using CADability.Attribute;
@@ -13,13 +11,10 @@ using CADability.WebDrawing;
 using Point = CADability.WebDrawing.Point;
 #else
 using System.Drawing;
-using Point = System.Drawing.Point;
 #endif
 using netDxf.Tables;
 using System.Text;
 using System.IO;
-using System.Diagnostics;
-using Polyline2D = netDxf.Entities.Polyline2D;
 
 namespace CADability.DXF
 {

--- a/CADability/LengthProperty.cs
+++ b/CADability/LengthProperty.cs
@@ -1,13 +1,10 @@
-﻿using CADability.GeoObject;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Globalization;
-using System.Reflection;
 
 namespace CADability.UserInterface
 {
     /// <summary>
-    /// Implements a hotspot <see cref="IHotSpot"/> to manipulate a lenth via a length property
+    /// Implements a hotspot <see cref="IHotSpot"/> to manipulate a length via a length property
     /// </summary>
     public class LengthHotSpot : IHotSpot, ICommandHandler
     {
@@ -140,8 +137,15 @@ namespace CADability.UserInterface
         protected override bool TextToValue(string text, out double val)
         {
             bool success = false;
-            if (numberFormatInfo.NumberDecimalSeparator == ".") text = text.Replace(",", ".");
-            if (numberFormatInfo.NumberDecimalSeparator == ",") text = text.Replace(".", ",");
+            if (numberFormatInfo.NumberDecimalSeparator == ".")
+                text = text.Replace(",", ".");
+
+            if (numberFormatInfo.NumberDecimalSeparator == ",")
+                text = text.Replace(".", ",");
+
+            //Remove duplicate NumberDecimalSeparator from end to start.
+            text = StringHelper.RemoveExtraStrings(text, numberFormatInfo.NumberDecimalSeparator);
+                
             val = 0.0;
             try
             {
@@ -155,28 +159,10 @@ namespace CADability.UserInterface
             catch (OverflowException)
             {
             }
-            //Locked = false;
-            if (!success)
-            {
-                try
-                {
-                    //Scripting s = new Scripting();
-                    //IFrame Frame = propertyPage.Frame;
-                    //if (Frame != null)
-                    //{
-                    //    if (numberFormatInfo.NumberDecimalSeparator == ",") text = text.Replace(",", "."); // this is ambiguous: there might be function calls with commas, 
-                    //    // which are destroyed here, but I don't know what to do. When using formulas, the user should be forced to have "." as decimal separator
-                    //    val = s.GetDouble(Frame.Project.NamedValues, text);
-                    //    success = true;
-                    //}
-                }
-                catch //(ScriptingException)
-                {
-                }
-            }
+            
             return success;
-
         }
+        
         protected override string ValueToText(double val)
         {
             return val.ToString("f", numberFormatInfo);

--- a/CADability/StringHelper.cs
+++ b/CADability/StringHelper.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace CADability
+{
+    public class StringHelper
+    {
+        /// <summary>
+        /// Remove duplicate strings from end to start and leave only one occurence.
+        /// </summary>
+        /// <param name="input">string to manipulate</param>
+        /// <param name="stringToRemove">string that will be removed</param>
+        /// <returns></returns>
+        public static string RemoveExtraStrings(string input, string stringToRemove)
+        {
+            if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(stringToRemove))
+                return input;
+
+            // Count the total number of occurrences of the string to remove
+            int count = 0;
+            int index = input.IndexOf(stringToRemove, StringComparison.Ordinal);
+            while (index != -1)
+            {
+                count++;
+                index = input.IndexOf(stringToRemove, index + stringToRemove.Length, StringComparison.Ordinal);
+            }
+
+            // If there are more than one occurrences, start removing from the end
+            if (count > 1)
+            {
+                int removeLength = stringToRemove.Length;
+                for (int i = input.Length - removeLength; i >= 0 && count > 1; i--)
+                {
+                    if (input.Substring(i, removeLength) == stringToRemove)
+                    {
+                        input = input.Remove(i, removeLength);
+                        count--;
+                    }
+                }
+            }
+
+            return input;
+        }
+
+    }
+}


### PR DESCRIPTION
Fix properties explorer refresh bug.

E.g. everytime a text is entered into the LengthProperty the caret is moved to the first position.

The input is now scanned for double DecimalSeperators. The last one is removed. This way the user can continue to enter the number after pressing comma or dot even if this char is already present.