### PR TITLE
fix(Model): remove valid check from add method

### DIFF
--- a/CADability/Model.cs
+++ b/CADability/Model.cs
@@ -915,7 +915,6 @@ namespace CADability
 		/// <param name="ObjectToAdd">The GeoObject to add</param>
 		public void Add(IGeoObject ObjectToAdd)
 		{
-			if (!ObjectToAdd.HasValidData()) return; // die Objekte überprüfen sich hier selbst
 			bool cancel = false;
 			if (AddingGeoObjectEvent != null) AddingGeoObjectEvent(ObjectToAdd, ref cancel);
 			if (cancel) return; // der Anwender hat was dagegen


### PR DESCRIPTION
I would like to remove the `HasValidData` check from the `Add(IGeoObject...` method on the model.

`Add(GeoObjectList...` & `Add(IEnumerable<IGeoObject>...` both don't check for this. The Model can contain invalid geometries anyway, so this check just leads to unexpected behavior.