### PR TITLE
Make Projection.SetClientRect() public

### DIFF
--- a/CADability/Projection.cs
+++ b/CADability/Projection.cs
@@ -1179,7 +1179,7 @@ namespace CADability
                 }
             }
         }
-        internal void SetClientRect(Rectangle clr)
+        public void SetClientRect(Rectangle clr)
         {
             this.clientRect = clr;
         }


### PR DESCRIPTION
The method `Projection.SetClientRect(Rectangle clr)` is currently internal. You need to set the client rectangle if you want to implement your own camera interaction on top of CADability's Projection class (which I am currently doing). Therefore, it would be quite useful if this method was public instead of internal.