### PR TITLE
Check if file exists before attempting to delete it

### DIFF
--- a/CADability/StringTable.cs
+++ b/CADability/StringTable.cs
@@ -85,7 +85,8 @@ namespace CADability.UserInterface
             AddString("deutsch", "MenuId.ToggleDebugFlag", Category.label, "Debug Flag");
             AddString("english", "MenuId.ToggleDebugFlag", Category.label, "Debug Flag");
 #if DEBUG
-            File.Delete(@"C:\Temp\MissingString.txt");
+            if (File.Exists(@"C:\Temp\MissingString.txt"))
+                File.Delete(@"C:\Temp\MissingString.txt");
 #endif
         }
 


### PR DESCRIPTION
When compiling CADability in debug mode, the code attempts to delete a `"C:\Temp\MissingString.txt"` file and crashes the program if this file doesn't exist. Check if the file exists before attempting to delete it.