### PR TITLE
Improve clipboard data handling with better error handling

### DIFF
--- a/CADability.Forms/CadFrame.cs
+++ b/CADability.Forms/CadFrame.cs
@@ -135,9 +135,18 @@ namespace CADability.Forms
         {
             if (data is IDataObject idata)
             {
-                if (idata.GetDataPresent(System.Windows.Forms.DataFormats.Serializable))
+                byte[] bytes = idata.GetData(typeof(byte[])) as byte[];
+                if (bytes != null)
                 {
-                    return idata.GetData(System.Windows.Forms.DataFormats.Serializable) as GeoObjectList;
+                    try
+                    {
+                        using (MemoryStream ms = new MemoryStream(bytes))
+                        {
+                            JsonSerialize js = new JsonSerialize();
+                            return js.FromStream(ms) as GeoObjectList;
+                        }
+                    }
+                    catch { }
                 }
             }
             return null;
@@ -307,21 +316,32 @@ namespace CADability.Forms
         }
         GeoObjectList IUIService.GetClipboardData()
         {
-            GeoObjectList objects = null;
-            IDataObject data = Clipboard.GetDataObject();
-            byte[] bytes = data.GetData(typeof(byte[])) as byte[];
-            if (bytes != null)
+            try
             {
-                MemoryStream ms = new MemoryStream(bytes);
-                JsonSerialize js = new JsonSerialize();
-                objects = js.FromStream(ms) as GeoObjectList;
-                ms.Dispose();
+                IDataObject data = Clipboard.GetDataObject();
+                if (data == null) return null;
+                byte[] bytes = data.GetData(typeof(byte[])) as byte[];
+                if (bytes != null)
+                {
+                    using (MemoryStream ms = new MemoryStream(bytes))
+                    {
+                        JsonSerialize js = new JsonSerialize();
+                        return js.FromStream(ms) as GeoObjectList;
+                    }
+                }
             }
-            return objects;
+            catch { }
+            return null;
         }
         bool IUIService.HasClipboardData()
         {
-            return ((IUIService)this).GetClipboardData() != null;
+            try
+            {
+                IDataObject data = Clipboard.GetDataObject();
+                return data != null && data.GetDataPresent(typeof(byte[]));
+            }
+            catch { }
+            return false;
         }
         event EventHandler IUIService.ApplicationIdle
         {


### PR DESCRIPTION
## Summary
Refactored clipboard data handling in CadFrame to improve robustness and consistency by adding comprehensive error handling and using `using` statements for proper resource management.

## Key Changes
- **GetDataPresent method**: Changed from checking `DataFormats.Serializable` to directly attempting to deserialize byte array data, with try-catch error handling
- **GetClipboardData method**: 
  - Added try-catch wrapper around entire method
  - Added null check for `Clipboard.GetDataObject()` result
  - Replaced manual `MemoryStream.Dispose()` call with `using` statement for proper resource cleanup
  - Simplified return logic to directly return deserialized result
- **HasClipboardData method**: 
  - Added try-catch wrapper
  - Optimized to check data presence without deserializing (checks for `byte[]` type presence)
  - Returns `false` on exception instead of calling `GetClipboardData()`

## Implementation Details
- All three clipboard-related methods now have consistent error handling with try-catch blocks that silently fail and return null/false
- Replaced manual resource disposal with `using` statements for `MemoryStream` objects
- Added defensive null checks before accessing clipboard data
- The `HasClipboardData()` optimization avoids unnecessary deserialization by only checking if byte array data is present in the clipboard

https://claude.ai/code/session_01Y178Q9RvuMC562i2QELpDX