### PR TITLE
Fix clipboard resource safety and restore drag-and-drop in CadFrame

### DIFF
--- a/CADability.Forms/CadFrame.cs
+++ b/CADability.Forms/CadFrame.cs
@@ -135,18 +135,9 @@ namespace CADability.Forms
         {
             if (data is IDataObject idata)
             {
-                byte[] bytes = idata.GetData(typeof(byte[])) as byte[];
-                if (bytes != null)
+                if (idata.GetDataPresent(System.Windows.Forms.DataFormats.Serializable))
                 {
-                    try
-                    {
-                        using (MemoryStream ms = new MemoryStream(bytes))
-                        {
-                            JsonSerialize js = new JsonSerialize();
-                            return js.FromStream(ms) as GeoObjectList;
-                        }
-                    }
-                    catch { }
+                    return idata.GetData(System.Windows.Forms.DataFormats.Serializable) as GeoObjectList;
                 }
             }
             return null;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Follow-up to #312, addressing the remaining review comments and a regression introduced by an incorrect fix.

### What changed

**`GetClipboardData`** (was missing from #312 review):
- Added null guard on `Clipboard.GetDataObject()` — can return null on empty/inaccessible clipboard
- Wrapped `MemoryStream` in `using` — previously `Dispose()` was not called if deserialization threw
- Added `try/catch` to prevent unhandled exceptions from propagating to callers

**`HasClipboardData`** (review comment R322):
- No longer calls `GetClipboardData()` — avoids full deserialization just to return a boolean
- Now checks `data.GetDataPresent(typeof(byte[]))` only, with error handling

**`GetDataPresent`** (review comment R134 — regression fix):
- My initial fix incorrectly changed this to use `byte[]` format, which broke drag-and-drop
- `GetDataPresent` handles drag-and-drop via `IDataObject`, where the drag source writes `DataFormats.Serializable` format in-process
- Reverted to `DataFormats.Serializable` — this is correct and safe for drag-and-drop (in-process, trusted source); the BinaryFormatter concern from #312 only applies to cross-process clipboard data

## Test plan
- [ ] Copy/paste objects in the drawing still works
- [ ] Drag-and-drop objects in the drawing still works
- [ ] Paste menu item is disabled when clipboard is empty

https://claude.ai/code/session_01Y178Q9RvuMC562i2QELpDX
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y178Q9RvuMC562i2QELpDX)_