### PR TITLE
Refactor menu item creation to support separators

### DIFF
--- a/CADability.Forms/MenuManager.cs
+++ b/CADability.Forms/MenuManager.cs
@@ -9,6 +9,13 @@ namespace CADability.Forms
         ICommandHandler commandHandler;
         public string menuID;
 
+        internal static ToolStripItem CreateItem(MenuWithHandler def)
+        {
+            if (def.ID == "SEPARATOR" || def.Text == "-")
+                return new ToolStripSeparator();
+            return new MenuItemWithHandler(def);
+        }
+
         public ContextMenuWithHandler(ToolStripMenuItem[] menuItems, ICommandHandler handler, string menuID) : base()
         {
             commandHandler = handler;
@@ -21,7 +28,7 @@ namespace CADability.Forms
             menuID = null;
             commandHandler = null;
             foreach (var def in definition)
-                Items.Add(new MenuItemWithHandler(def));
+                Items.Add(CreateItem(def));
             Closed += (s, e) => MenuItemWithHandler.HideToolTip();
         }
 
@@ -202,7 +209,7 @@ namespace CADability.Forms
             if (definition.SubMenus != null)
             {
                 foreach (var sub in definition.SubMenus)
-                    DropDownItems.Add(new MenuItemWithHandler(sub));
+                    DropDownItems.Add(ContextMenuWithHandler.CreateItem(sub));
             }
             DropDownOpening += HandleDropDownOpening;
         }
@@ -244,7 +251,7 @@ namespace CADability.Forms
         {
             MenuStrip res = new MenuStrip();
             foreach (var def in definition)
-                res.Items.Add(new MenuItemWithHandler(def));
+                res.Items.Add(ContextMenuWithHandler.CreateItem(def));
             res.MenuDeactivate += (s, e) => MenuItemWithHandler.HideToolTip();
             return res;
         }


### PR DESCRIPTION
## Summary
Extracted menu item creation logic into a reusable factory method to properly handle separator items across different menu contexts (context menus, dropdown menus, and main menus).

## Key Changes
- Added `CreateItem()` static factory method to `ContextMenuWithHandler` that:
  - Detects separator items by checking for ID "SEPARATOR" or text "-"
  - Returns `ToolStripSeparator` for separators
  - Returns `MenuItemWithHandler` for regular menu items
- Updated three locations to use the new factory method instead of directly instantiating `MenuItemWithHandler`:
  - `ContextMenuWithHandler` constructor
  - `MenuItemWithHandler` constructor (for sub-menus)
  - `MakeMainMenu()` static method

## Implementation Details
This change ensures consistent handling of menu separators across all menu creation paths. Previously, separators could only be created through direct instantiation, which wasn't possible in all contexts. The factory method centralizes this logic and makes it available wherever menu items are being created.

https://claude.ai/code/session_016kEw8Ky8FahMbbJSUPmucJ