### PR TITLE
The Clone method of the SphericalSurface didn't copy the usedArea. Th…

### DIFF
--- a/CADability/SphericalSurface.cs
+++ b/CADability/SphericalSurface.cs
@@ -516,7 +516,7 @@ namespace CADability.GeoObject
 		/// <returns></returns>
 		public override ISurface Clone()
 		{
-			return new SphericalSurface(toSphere);
+			return new SphericalSurface(toSphere, usedArea);
 		}
 		/// <summary>
 		/// Overrides <see cref="CADability.GeoObject.ISurfaceImpl.Modify (ModOp)"/>


### PR DESCRIPTION
…is will cause exception when computing the intersection of a spline with a sphere.