### PR TITLE
[twobrains] Fix unreliable OctTree hit testing for free-form BSplines

### DIFF
--- a/CADability/BSpline2D.cs
+++ b/CADability/BSpline2D.cs
@@ -1121,7 +1121,7 @@ namespace CADability.Curve2D
                 if (zMax < p.z) zMax = p.z;
             }
         }
-        protected override void GetTriangulationBasis(out GeoPoint2D[] points, out GeoVector2D[] directions, out double[] parameters)
+        private double[] GetTriangulationKnots()
         {
             double[] tknots = knots;
             if (knots.Length == 2)
@@ -1131,6 +1131,36 @@ namespace CADability.Curve2D
                 tknots[1] = (knots[0] + knots[1]) / 2.0;
                 tknots[2] = knots[1];
             }
+            // The triangulation based HitTest relies on each span's control triangle enclosing the
+            // curve, which only holds while a span turns less than ~180°. Free-form splines with few
+            // knots have spans that turn too much, so the coarse triangle test rejects them and only
+            // the knot points (notably the curve start/end) register as hits. Subdivide such spans by
+            // turning angle so the resulting triangles stay tight enough to bound the curve.
+            const double maxSpanAngle = Math.PI / 4.0; // 45° per sub-span
+            List<double> res = new List<double>(tknots.Length);
+            for (int i = 0; i < tknots.Length - 1; i++)
+            {
+                res.Add(tknots[i]);
+                GeoVector2D d0 = DirectionAtParam(tknots[i]);
+                GeoVector2D d1 = DirectionAtParam(tknots[i + 1]);
+                if (!d0.IsNullVector() && !d1.IsNullVector())
+                {
+                    double dot = d0.x * d1.x + d0.y * d1.y;
+                    double cross = d0.x * d1.y - d0.y * d1.x;
+                    double angle = Math.Atan2(Math.Abs(cross), dot); // [0, pi], directions are normalized
+                    int sub = (int)Math.Ceiling(angle / maxSpanAngle);
+                    for (int j = 1; j < sub; j++)
+                    {
+                        res.Add(tknots[i] + (tknots[i + 1] - tknots[i]) * j / sub);
+                    }
+                }
+            }
+            res.Add(tknots[tknots.Length - 1]);
+            return res.ToArray();
+        }
+        protected override void GetTriangulationBasis(out GeoPoint2D[] points, out GeoVector2D[] directions, out double[] parameters)
+        {
+            double[] tknots = GetTriangulationKnots();
             points = new GeoPoint2D[tknots.Length];
             directions = new GeoVector2D[tknots.Length];
             parameters = new double[tknots.Length];
@@ -1142,14 +1172,7 @@ namespace CADability.Curve2D
         }
         internal override void GetTriangulationPoints(out GeoPoint2D[] points, out double[] parameters)
         {
-            double[] tknots = knots;
-            if (knots.Length == 2)
-            {   // there are splines with only two knots and degree 14 which represent a full circle. We invent an additional knot
-                tknots = new double[3];
-                tknots[0] = knots[0];
-                tknots[1] = (knots[0] + knots[1]) / 2.0;
-                tknots[2] = knots[1];
-            }
+            double[] tknots = GetTriangulationKnots();
             points = new GeoPoint2D[tknots.Length];
             parameters = new double[tknots.Length];
             for (int i = 0; i < tknots.Length; i++)

--- a/CADability/BSpline2D.cs
+++ b/CADability/BSpline2D.cs
@@ -1138,10 +1138,10 @@ namespace CADability.Curve2D
             // turning angle so the resulting triangles stay tight enough to bound the curve.
             const double maxSpanAngle = Math.PI / 4.0; // 45° per sub-span
             List<double> res = new List<double>(tknots.Length);
+            GeoVector2D d0 = DirectionAtParam(tknots[0]);
             for (int i = 0; i < tknots.Length - 1; i++)
             {
                 res.Add(tknots[i]);
-                GeoVector2D d0 = DirectionAtParam(tknots[i]);
                 GeoVector2D d1 = DirectionAtParam(tknots[i + 1]);
                 if (!d0.IsNullVector() && !d1.IsNullVector())
                 {
@@ -1154,6 +1154,7 @@ namespace CADability.Curve2D
                         res.Add(tknots[i] + (tknots[i + 1] - tknots[i]) * j / sub);
                     }
                 }
+                d0 = d1;
             }
             res.Add(tknots[tknots.Length - 1]);
             return res.ToArray();


### PR DESCRIPTION
**Problem**

Hit testing a BSpline2D via the OctTree (onlyInside = false) was unreliable for free-form splines: only picks on the curve's start/end (and other knot points) registered, while picks on the curve between knots were missed. Circular/spiral splines and the onlyInside = true (subsumption) path were unaffected.

**Cause**

GeneralCurve2D.HitTest tests each triangulation span against a coarse control triangle (chord + tangent-intersection apex) and early-outs if the pick rect misses it, before any adaptive subdivision runs. That triangle only encloses the curve while the span turns less than ~180 degrees. BSpline2D builds its triangulation by sampling distinct knot values only, so free-form splines with few knots produce spans that turn too much. The control triangle no longer bounds the curve, and mid-span picks are rejected. The only reliable hits are points that are both on the curve and a triangle vertex, i.e. the knot points. Spirals built from many closely-spaced through-points get short, gently-curved spans, which is why they already worked.

**Fix**

BSpline2D now subdivides any knot span whose tangent turns more than 45° into evenly-spaced sub-spans, so the control triangles stay tight enough to enclose the curve. Spans that already turn ≤45° are sampled exactly as before, so existing well-behaved cases are unchanged; only over-curved free-form spans gain extra points.