### PR TITLE
Fix NRE when calling Remove() on empty OctTree

### DIFF
--- a/CADability/OctTree.cs
+++ b/CADability/OctTree.cs
@@ -456,7 +456,7 @@ namespace CADability
             {
                 if (ppp == null)
                 {
-                    list.Remove(objectToRemove);
+                    list?.Remove(objectToRemove);
                 }
                 else
                 {


### PR DESCRIPTION
**Problem**

The OctTree nodes keep an internal reference to a HashSet of GeoObjects which is only assigned once a GeoObject with a non-zero extent (BoundingCube) is added to the OctTree. That means that calling Remove() on an empty OctTree throws a NullReferenceException, because this HashSet reference is null.

**Fix**

Add a null conditional operator to the internal Remove() call to skip it if the node hasn't been properly initialized yet.