### PR TITLE
[twobrains] Raise C# language level from 7.3 to 11

### DIFF
--- a/CADability/CADability.csproj
+++ b/CADability/CADability.csproj
@@ -20,6 +20,7 @@
     <AssemblyName>CADability</AssemblyName>
     <Platforms>AnyCPU;x64</Platforms>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <LangVersion>11.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">


### PR DESCRIPTION
This allows using more modern language features, especially super basic ones like nullable ref types. Things like `string?` etc are heavily needed.