### PR TITLE
[twobrains] Fix redundant HitTest calls in OctTree rectangle queries

### DIFF
--- a/CADability/OctTree.cs
+++ b/CADability/OctTree.cs
@@ -494,7 +494,7 @@ namespace CADability
                     }
                 }
             }
-            internal void GetObjectsFromRect(Projection projection, BoundingRect rect, bool onlyInside, Set<TT> addToList)
+            internal void GetObjectsFromRect(Projection projection, BoundingRect rect, bool onlyInside, Set<TT> addToList, HashSet<TT> alreadyTested)
             {
                 if (cube.Interferes(projection, rect))
                 {
@@ -502,7 +502,7 @@ namespace CADability
                     {
                         foreach (TT item in list)
                         {
-                            if (!addToList.Contains(item) && item.HitTest(projection, rect, onlyInside))
+                            if (alreadyTested.Add(item) && item.HitTest(projection, rect, onlyInside))
                             {
                                 addToList.Add(item);
                             }
@@ -510,18 +510,18 @@ namespace CADability
                     }
                     else if (ppp != null)
                     {
-                        ppp.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        mpp.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        pmp.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        mmp.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        ppm.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        mpm.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        pmm.GetObjectsFromRect(projection, rect, onlyInside, addToList);
-                        mmm.GetObjectsFromRect(projection, rect, onlyInside, addToList);
+                        ppp.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        mpp.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        pmp.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        mmp.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        ppm.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        mpm.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        pmm.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
+                        mmm.GetObjectsFromRect(projection, rect, onlyInside, addToList, alreadyTested);
                     }
                 }
             }
-            internal void GetObjectsFromRect(Projection.PickArea area, bool onlyInside, Set<TT> addToList)
+            internal void GetObjectsFromRect(Projection.PickArea area, bool onlyInside, Set<TT> addToList, HashSet<TT> alreadyTested)
             {
                 if (area == null) return;
                 if (cube.Interferes(area))
@@ -530,7 +530,7 @@ namespace CADability
                     {
                         foreach (TT item in list)
                         {
-                            if (!addToList.Contains(item) && item.HitTest(area, onlyInside))
+                            if (alreadyTested.Add(item) && item.HitTest(area, onlyInside))
                             {
                                 addToList.Add(item);
                             }
@@ -538,14 +538,14 @@ namespace CADability
                     }
                     else if (ppp != null)
                     {
-                        ppp.GetObjectsFromRect(area, onlyInside, addToList);
-                        mpp.GetObjectsFromRect(area, onlyInside, addToList);
-                        pmp.GetObjectsFromRect(area, onlyInside, addToList);
-                        mmp.GetObjectsFromRect(area, onlyInside, addToList);
-                        ppm.GetObjectsFromRect(area, onlyInside, addToList);
-                        mpm.GetObjectsFromRect(area, onlyInside, addToList);
-                        pmm.GetObjectsFromRect(area, onlyInside, addToList);
-                        mmm.GetObjectsFromRect(area, onlyInside, addToList);
+                        ppp.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        mpp.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        pmp.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        mmp.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        ppm.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        mpm.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        pmm.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
+                        mmm.GetObjectsFromRect(area, onlyInside, addToList, alreadyTested);
                     }
                 }
             }
@@ -1205,7 +1205,7 @@ namespace CADability
         {
             //GeoObjectList dbg = DebugCheck(delegate(IOctTreeInsertable[] theList, BoundingCube bc) { return bc.Interferes(projection, rect); });
             Set<T> addToList = new Set<T>();
-            node.GetObjectsFromRect(projection, rect, onlyInside, addToList);
+            node.GetObjectsFromRect(projection, rect, onlyInside, addToList, new HashSet<T>());
             return addToList.ToArray();
         }
         /// <summary>
@@ -1220,7 +1220,7 @@ namespace CADability
         {
             //GeoObjectList dbg = DebugCheck(delegate(IOctTreeInsertable[] theList, BoundingCube bc) { return bc.Interferes(projection, rect); });
             Set<T> addToList = new Set<T>();
-            node.GetObjectsFromRect(area, onlyInside, addToList);
+            node.GetObjectsFromRect(area, onlyInside, addToList, new HashSet<T>());
             return addToList.ToArray();
         }
         /// <summary>


### PR DESCRIPTION
GetObjectsFromRect re-evaluates each object's HitTest once per OctTree node the object occupies. Since a HitTest(projection, rect, onlyInside) result depends only on the object, projection, and rect (not on the node) this is redundant work for any large object (e.g. a BSpline) that spans many nodes.

The only existing guard was !addToList.Contains(item), which short-circuits objects that have already been added, i.e. it only caches hits. In onlyInside (subsumption) mode, an object partially outside the rectangle returns false from every node, never enters addToList, and so gets its expensive HitTest (projected-curve rebuild & full triangulation for BSpline) recomputed for each node, on every query. This makes rubber-band selection over splines visibly lag.

This change threads a per-query HashSet through the traversal and gates HitTest on alreadyTested.Add(item), so each object is tested exactly once per query regardless of how many nodes it spans, caching misses as well as hits. Applied to both the BoundingRect and Projection.PickArea overloads. No behavioural change to the returned set, only redundant work is removed.