### PR TITLE
Switch NuGet publishing to OIDC token authentication

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -6,21 +6,35 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '6.0.x'
       - name: Restore dependencies
         run: dotnet restore CADability/CADability.csproj
       - name: Build
         run: dotnet build CADability/CADability.csproj -c Release --no-restore
       - name: Pack
         run: dotnet pack CADability/CADability.csproj -c Release --no-build -o ./nupkgs
+      - name: Get NuGet publish token
+        run: |
+          $tokenRequest = Invoke-RestMethod `
+            -Uri "$env:ACTIONS_ID_TOKEN_REQUEST_URL&audience=nuget.org" `
+            -Headers @{Authorization = "Bearer $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN"}
+          $body = ConvertTo-Json @{oidcToken = $tokenRequest.value}
+          $nugetToken = (Invoke-RestMethod `
+            -Method Post `
+            -Uri "https://www.nuget.org/packages/publish/oidc" `
+            -Body $body `
+            -ContentType "application/json").token
+          Write-Output "::add-mask::$nugetToken"
+          echo "NUGET_TOKEN=$nugetToken" >> $env:GITHUB_ENV
       - name: Push NuGet package
         run: |
-          $version = "${{ github.ref_name }}" -replace '^v', ''
-          $pkg = Get-ChildItem -Path ./nupkgs -Filter "*$version.nupkg" | Select-Object -First 1
-          dotnet nuget push "$($pkg.FullName)" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          $pkg = Get-ChildItem -Path ./nupkgs -Filter "*.nupkg" | Select-Object -First 1
+          dotnet nuget push "$($pkg.FullName)" --api-key "$env:NUGET_TOKEN" --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -12,19 +12,15 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Restore dependencies
         run: dotnet restore CADability/CADability.csproj
       - name: Build
         run: dotnet build CADability/CADability.csproj -c Release --no-restore
-      - name: List build output
-        run: dir CADability\bin\Release\netstandard2.0
       - name: Pack
         run: dotnet pack CADability/CADability.csproj -c Release --no-build -o ./nupkgs
-      - name: List nupkg
-        run: dir .\nupkgs
       - name: Push NuGet package
         run: |
           $version = "${{ github.ref_name }}" -replace '^v', ''
           $pkg = Get-ChildItem -Path ./nupkgs -Filter "*$version.nupkg" | Select-Object -First 1
-          dotnet nuget push $pkg.FullName --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+          dotnet nuget push "$($pkg.FullName)" --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
## Summary
Updated the NuGet publishing workflow to use OpenID Connect (OIDC) token-based authentication instead of static API keys, improving security by eliminating the need to store long-lived secrets.

## Key Changes
- Added `id-token: write` permission to the GitHub Actions workflow to enable OIDC token generation
- Implemented OIDC token exchange flow to obtain a temporary NuGet authentication token from nuget.org
- Replaced static `NUGET_API_KEY` secret with dynamically generated OIDC token
- Removed version-based package filtering logic; now publishes the first `.nupkg` file found
- Added `--skip-duplicate` flag to gracefully handle re-runs without failing on duplicate package versions
- Removed debug `dir` commands that listed build output and nupkg contents

## Implementation Details
The new authentication flow:
1. Requests an OIDC token from GitHub's token endpoint
2. Exchanges the OIDC token with nuget.org's OIDC endpoint to obtain a temporary NuGet API token
3. Masks the token in logs for security
4. Uses the temporary token for package publishing

This approach follows NuGet's recommended security best practices and eliminates the need to manage API key secrets in the repository.

https://claude.ai/code/session_01RUo8UZKTRWRTH7QHa68nD8