### PR TITLE
Use official NuGet/login@v1 action for Trusted Publishing

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,11 +21,12 @@ jobs:
         run: dotnet build CADability/CADability.csproj -c Release --no-restore
       - name: Pack
         run: dotnet pack CADability/CADability.csproj -c Release --no-build -o ./nupkgs
+      - name: Login to NuGet
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: FriendsOfCADability
       - name: Push NuGet package
         run: |
-          $oidcToken = (Invoke-RestMethod `
-            -Uri "$env:ACTIONS_ID_TOKEN_REQUEST_URL&audience=nuget.org" `
-            -Headers @{Authorization = "Bearer $env:ACTIONS_ID_TOKEN_REQUEST_TOKEN"}).value
-          Write-Output "::add-mask::$oidcToken"
           $pkg = Get-ChildItem -Path ./nupkgs -Filter "*.nupkg" | Select-Object -First 1
-          dotnet nuget push "$($pkg.FullName)" --api-key $oidcToken --source https://api.nuget.org/v3/index.json --skip-duplicate
+          dotnet nuget push "$($pkg.FullName)" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate


### PR DESCRIPTION
Previous attempts used the wrong OIDC audience (nuget.org instead of https://www.nuget.org) and wrong exchange endpoint. The NuGet/login@v1 action handles all of this correctly: it requests the OIDC token with the right audience, exchanges it at https://www.nuget.org/api/v2/token, and outputs a short-lived NUGET_API_KEY for the push step.


Claude-Session: https://claude.ai/code/session_01RUo8UZKTRWRTH7QHa68nD8