### PR TITLE
Fix context menu disposal and reorganize CLSCompliant attribute

### DIFF
--- a/CADability.Forms/MenuManager.cs
+++ b/CADability.Forms/MenuManager.cs
@@ -251,6 +251,7 @@ namespace CADability.Forms
             if (definition.Target != null) definition.Target.OnCommand(definition.ID);
 
             // find and dispose the root ContextMenuWithHandler to avoid blank menu text accumulation
+            // defer disposal so WinForms can finish its closing sequence before the object is released
             ToolStrip ts = this.Owner;
             while (ts != null && !(ts is ContextMenuWithHandler))
             {
@@ -258,7 +259,14 @@ namespace CADability.Forms
                     ts = ddm.OwnerItem.Owner;
                 else break;
             }
-            (ts as ContextMenuWithHandler)?.Dispose();
+            if (ts is ContextMenuWithHandler rootMenu && !rootMenu.IsDisposed)
+            {
+                rootMenu.BeginInvoke((Action)(() =>
+                {
+                    if (!rootMenu.IsDisposed)
+                        rootMenu.Dispose();
+                }));
+            }
         }
 
         protected override void OnDropDownShow(EventArgs e)

--- a/CADability/Algorithms.cs
+++ b/CADability/Algorithms.cs
@@ -15,9 +15,6 @@ using System.Collections.Generic;
 // Make internals of this library available to the unit test framework.
 //[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("UnitTests")]
 
-// Everything should be CLS compliant.
-[assembly: CLSCompliant(true)]
-
 
 namespace Wintellect.PowerCollections
 {

--- a/CADability/Properties/AssemblyInfo.cs
+++ b/CADability/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(true)]


### PR DESCRIPTION
## Summary
This PR addresses two issues: a potential race condition in context menu disposal and improves code organization by moving the CLSCompliant assembly attribute to a dedicated AssemblyInfo.cs file.

## Key Changes

- **Deferred context menu disposal**: Modified `MenuManager.OnClick()` to defer the disposal of the root `ContextMenuWithHandler` using `BeginInvoke()`. This ensures WinForms can complete its menu closing sequence before the object is released, preventing potential issues with blank menu text accumulation.

- **Added null/disposed checks**: Added explicit checks to verify the root menu exists and hasn't already been disposed before attempting disposal, making the code more defensive.

- **Reorganized CLSCompliant attribute**: Moved the `[assembly: CLSCompliant(true)]` attribute from `Algorithms.cs` to a new dedicated `Properties/AssemblyInfo.cs` file, following standard .NET conventions for assembly-level attributes.

## Implementation Details

The context menu disposal now uses `BeginInvoke()` to schedule disposal on the UI thread after the current message is processed, allowing WinForms to safely complete its internal cleanup before the menu object is released. This prevents potential ObjectDisposedException or state corruption issues that could occur from immediate disposal during the menu closing sequence.

https://claude.ai/code/session_01JR5bGFDY4UYtSUEotBcu8z