### PR TITLE
Remove DxfImport.Handle user data assignment

### DIFF
--- a/CADability/ImportDxf.cs
+++ b/CADability/ImportDxf.cs
@@ -317,7 +317,7 @@ namespace CADability.DXF
 
                 go.UserData.Add(name, xdata);
             }
-            go.UserData["DxfImport.Handle"] = new UserInterface.StringProperty(entity.Handle, "DxfImport.Handle");
+
         }
         private GeoObject.Block FindBlock(netDxf.Blocks.Block entity)
         {


### PR DESCRIPTION
## Summary
Removed the assignment of DxfImport.Handle user data during DXF entity import.

## Changes
- Removed the line that added the DXF entity handle as user data to imported GeoObjects
- This line was the only statement in the SetUserData method after the xdata loop, leaving the method to only process xdata properties

## Details
The `SetUserData` method in ImportDxf.cs previously stored the DXF entity's handle as a StringProperty in the GeoObject's UserData dictionary. This assignment has been removed, simplifying the user data handling to focus only on xdata properties from the DXF entity.

https://claude.ai/code/session_019vLRjpBDWWSVgQqpZ651MT