### PR TITLE
Fix multi-GB memory consumption when zooming into smooth solids

### DIFF
--- a/CADability/Face.cs
+++ b/CADability/Face.cs
@@ -5764,6 +5764,8 @@ namespace CADability.GeoObject
         private object lockTriangulationRecalc;
         private object lockTriangulationData;
         private GeoPoint[] trianglePoint;
+        private GeoVector[] triangleNormal;    // cached normals for trianglePoint (see PaintFaceTo3D)
+        private GeoPoint[] triangleNormalFor;  // the trianglePoint array the cache was computed for
         private GeoPoint2D[] triangleUVPoint;
         private int[] triangleIndex;
         private double trianglePrecision;
@@ -6910,14 +6912,22 @@ namespace CADability.GeoObject
                                 paintTo3D.SetColor(colorDef.Color);
                         }
                     }
-                    GeoVector[] normals = new GeoVector[trianglePoint.Length];
-                    for (int i = 0; i < trianglePoint.Length; ++i)
+                    // The normals only depend on the triangulation: cache them instead of
+                    // recomputing surface.GetNormal for every vertex on every paint — for a
+                    // finely tessellated face that was hundreds of thousands of evaluations
+                    // and a multi MB allocation per frame/recording.
+                    if (triangleNormal == null || !ReferenceEquals(triangleNormalFor, trianglePoint))
                     {
-                        normals[i] = surface.GetNormal(triangleUVPoint[i]);
-                        normals[i].NormIfNotNull();
-
+                        GeoVector[] normals = new GeoVector[trianglePoint.Length];
+                        for (int i = 0; i < trianglePoint.Length; ++i)
+                        {
+                            normals[i] = surface.GetNormal(triangleUVPoint[i]);
+                            normals[i].NormIfNotNull();
+                        }
+                        triangleNormal = normals;
+                        triangleNormalFor = trianglePoint;
                     }
-                    paintTo3D.Triangle(trianglePoint, normals, triangleIndex);
+                    paintTo3D.Triangle(trianglePoint, triangleNormal, triangleIndex);
                 }
             }
         }

--- a/CADability/Model.cs
+++ b/CADability/Model.cs
@@ -308,6 +308,17 @@ namespace CADability
 				if (!data.CancellationToken.IsCancellationRequested) //If the background thread was aborted during waiting the pool threads, this precision was not computed til the end, ignore it.
 				{
 					displayListPrecision = data.Precision;
+
+					// Triangulating a large smooth surface allocates far more transient data than
+					// remains cached; the aggressive collection also returns the committed heap
+					// segments of that churn to the OS (an ordinary compaction left the process
+					// at ~1 GB working set with only 55 MB of live objects). It must run BEFORE
+					// NewDisplaylistAvailableEvent: that event invalidates the views, so the UI
+					// thread starts rebuilding the display lists immediately and a collection
+					// afterwards would run concurrently with (and be defeated by) that churn.
+					// We are on a background thread, nothing else is running at this point.
+					CollectAggressive();
+
 					displayListsDirty = true; // damits einen Repaint gibt
 											  // System.Diagnostics.Trace.WriteLine("NewDisplaylistAvailableEvent, Genauigkeit: " + precision.ToString());
 					if (NewDisplaylistAvailableEvent != null) NewDisplaylistAvailableEvent(this);
@@ -325,32 +336,61 @@ namespace CADability
 			}
 		}
 
+		/// <summary>
+		/// Full blocking collection that also returns committed heap segments to the OS.
+		/// Triangulating large smooth surfaces leaves the process with hundreds of MB of
+		/// committed-but-empty GC segments (e.g. 55 MB of live objects in a 1 GB working
+		/// set); an ordinary forced compacting collection cleans the heap but never
+		/// decommits. On .NET 7+ GCCollectionMode.Aggressive (enum value 4) does; older
+		/// runtimes fall back to a plain compacting collection.
+		/// </summary>
+		private static void CollectAggressive()
+		{
+			try
+			{
+				GC.Collect(2, (GCCollectionMode)4, true, true); // GCCollectionMode.Aggressive, .NET 7+
+			}
+			catch (ArgumentException)
+			{
+				System.Runtime.GCSettings.LargeObjectHeapCompactionMode = System.Runtime.GCLargeObjectHeapCompactionMode.CompactOnce;
+				GC.Collect(2, GCCollectionMode.Forced, true, true);
+			}
+		}
+
 		internal void RecalcDisplayLists(IPaintTo3D paintTo3D)
 		{   // wird vom Paint in ProjectedModel aufgerufen, wenn dieser "dirty" ist
 			// kann aber nacheinander von mehreren ProjectedModels aufgerufen werden und soll nur einmal berechnet werden
 			if (paintTo3D.Precision < displayListPrecision && !paintTo3D.DontRecalcTriangulation)
 			{
-				double recalcPrecision = paintTo3D.Precision / 2.0; // /2.0, damit es nicht sooft drankommt
-				if (manageBackgroundRecalc != null)
+				// Compute exactly the precision that is displayed. This used to be
+				// paintTo3D.Precision / 2.0 ("damit es nicht sooft drankommt"), but that
+				// speculation started a full re-triangulation at four times the displayed
+				// triangle count after every zoom pause — for a single sphere that was a 20
+				// second background burn allocating gigabytes, followed by another complete
+				// display list rebuild for detail nobody had asked for. Zooming further in
+				// now simply starts the next round at the then needed precision.
+				double recalcPrecision = paintTo3D.Precision;
+				// safety net: never triangulate finer than the finest precision ModelView can
+				// ever request (Extent.MaxSide/HighestDisplayPrecision)
+				double precisionFactor = Settings.GlobalSettings.GetDoubleValue("HighestDisplayPrecision", 1e5);
+				double finestUseful = Extent.MaxSide / precisionFactor;
+				if (recalcPrecision < finestUseful) recalcPrecision = finestUseful;
+				if (recalcPrecision < displayListPrecision) // otherwise there is nothing finer to compute
 				{
-					if (recalcPrecision >= backgroundRecalcPrecision) //If zooming a lot after a while the precision doesn't change anymore.
+					if (manageBackgroundRecalc != null)
 					{
+						// A computation is already running. Do not abort and respawn it for every
+						// zoom notch: during a fast zoom gesture that produced a cascade of aborted
+						// rounds, each leaving hundreds of MB of partial triangulation garbage.
+						// Let it finish — the next paint still sees Precision < displayListPrecision
+						// and starts the finer level then, so the display converges sequentially.
 						return;
 					}
-
-					// abbrechen und warten
-					Thread t = manageBackgroundRecalc;
-					if (t != null)
-					{
-						//System.Diagnostics.Trace.WriteLine("Background Task abgebrochen, Genauigkeit: " + paintTo3D.Precision.ToString());
-						AbortBackgroundRecalc();
-						t.Join(); // manageBackgroundRecalc kann hier drin null werden
-					}
+					cancellationTokenSource = new CancellationTokenSource();
+					manageBackgroundRecalc = new Thread(DoBackgroundRecalcDisplayList);
+					manageBackgroundRecalc.Start(new DoBackgroundRecalcDisplayListData() { Precision = recalcPrecision, CancellationToken = cancellationTokenSource.Token }); // /2.0, damit es nicht sooft drankommt
+																																											  //System.Diagnostics.Trace.WriteLine("Background Task gestartet, Genauigkeit: " + paintTo3D.Precision.ToString());
 				}
-				cancellationTokenSource = new CancellationTokenSource();
-				manageBackgroundRecalc = new Thread(DoBackgroundRecalcDisplayList);
-				manageBackgroundRecalc.Start(new DoBackgroundRecalcDisplayListData() { Precision = recalcPrecision, CancellationToken = cancellationTokenSource.Token }); // /2.0, damit es nicht sooft drankommt
-																																										  //System.Diagnostics.Trace.WriteLine("Background Task gestartet, Genauigkeit: " + paintTo3D.Precision.ToString());
 			}
 			if (displayListsDirty) // nur wenn kein BackgroundRecalc läuft
 			{
@@ -410,6 +450,17 @@ namespace CADability
 					layerTransparentObjects.Clear();
 					layerCurveObjects.Clear();
 					displayListsDirty = false;
+					// Recording finely tessellated geometry churns through large transient
+					// arrays which ordinary collections do not reclaim promptly; without this
+					// the heap stayed at the churn peak (> 1 GB observed). This is the one
+					// reliably quiet-and-effective collection point (the background thread's
+					// own collect races the just-exiting workers), so the gate is an ABSOLUTE
+					// threshold: a delta gate missed the case where the heap was already
+					// ballooned entering the rebuild. Small models never reach it.
+					if (GC.GetTotalMemory(false) > 300 * 1024 * 1024)
+					{
+						CollectAggressive();
+					}
 				}
 				catch (PaintTo3DOutOfMemory)
 				{


### PR DESCRIPTION
## Summary

Zooming deeply into a single sphere drove the process from ~70 MB to 2.3 GB, and the memory never came back. The investigation (driven by per-second heap instrumentation over ten diagnostic rounds) showed the memory is not held by rendering — it is triangulation churn and GC bookkeeping in the core, and it behaves the same with the old OpenGL renderer as with the Silk.NET branch. These fixes are therefore independent of the renderer migration (#339).

## Root causes and fixes

**1. Background re-triangulation abort cascade** (`Model.RecalcDisplayLists`)
Every zoom notch aborted the running background re-triangulation thread and respawned it at the next finer precision. A fast zoom gesture produced a cascade of aborted rounds, each abandoning its partial triangulation results as garbage (~280 MB/s of heap growth was measured with zero user interaction and zero painting). A running round now finishes; the next finer level starts on a later paint, so levels are computed sequentially and each at most once. Aborts on object add/remove are unchanged.

**2. Speculative half-precision rounds** (`Model.RecalcDisplayLists`)
The background round triangulated at `Precision / 2.0` ("damit es nicht sooft drankommt"): after every zoom pause, a full re-triangulation with 4× the displayed triangle count ran for many seconds, and its completion forced another complete display list rebuild to swap in detail nobody had asked for. Rounds now compute exactly the displayed precision, clamped to the finest precision `ModelView` can ever request (`Extent.MaxSide / HighestDisplayPrecision`).

**3. Committed heap segments never returned to the OS**
The triangulation transients survived into gen2/LOH, and an ordinary forced compacting collection cleans the heap but never decommits: the process was measured at **55 MB of live objects inside a 1042 MB committed heap**. A collection helper using `GCCollectionMode.Aggressive` (.NET 7+, value 4, with a compacting fallback for older runtimes so the netstandard2.0 target keeps working) now runs when a background round completes — before `NewDisplaylistAvailableEvent`, so it cannot race the UI rebuild that event triggers — and after any display list rebuild that ends with the heap above 300 MB (an absolute gate; a delta gate missed rebuilds entered with an already-ballooned heap).

**4. Normals recomputed on every paint** (`Face.PaintFaceTo3D`)
All vertex normals were recomputed and reallocated on every paint call — for a zoomed sphere a fresh multi-MB `GeoVector[]` plus hundreds of thousands of `surface.GetNormal` evaluations per frame or display list recording. The normals only depend on the triangulation and are now cached alongside it, invalidated by reference identity of the `trianglePoint` array.

## Measurements

| Scenario | Before | After |
|---|---|---|
| Sphere, zoom to precision floor, then wait | 2.3 GB, permanent | 12.9 MB live managed heap; committed segments returned to the OS |
| Post-zoom idle | +280 MB/s growth for ~20 s | flat |
| 2D-only models | unaffected | unaffected (collection gates never reached) |

## Notes

- The transient peak *during* a heavy triangulation round (~1–2 GB for a few seconds while two ~120k-triangle faces compute in parallel) is the triangulation algorithm's inherent working memory and is unchanged — it is now reliably reclaimed afterwards.
- Verified by compilation on Linux (netstandard2.0/net8) and by repeated instrumented runs on Windows; the instrumentation itself is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HjM12HeHU7a7n9DJx91Y4

---
_Generated by [Claude Code](https://claude.ai/code/session_014HjM12HeHU7a7n9DJx91Y4)_