### PR TITLE
Fix null reference exception in ProjectedModel.Disconnect

### DIFF
--- a/CADability/ProjectedModel.cs
+++ b/CADability/ProjectedModel.cs
@@ -286,10 +286,16 @@ namespace CADability
         }
         public void Disconnect(IPaintTo3D paintTo3D)
         {
-            foreach (IPaintTo3DList plist in allCurves) plist.Dispose();
-            foreach (IPaintTo3DList plist in allFaces) plist.Dispose();
-            foreach (IPaintTo3DList plist in allTransparent) plist.Dispose();
-            foreach (IPaintTo3DList plist in allUnscaled) plist.Dispose();
+            // entries may be null: IPaintTo3D.CloseList returns null for display lists without content
+            foreach (IPaintTo3DList plist in allCurves) plist?.Dispose();
+            foreach (IPaintTo3DList plist in allFaces) plist?.Dispose();
+            foreach (IPaintTo3DList plist in allTransparent) plist?.Dispose();
+            foreach (IPaintTo3DList plist in allUnscaled) plist?.Dispose();
+            allCurves.Clear();
+            allFaces.Clear();
+            allTransparent.Clear();
+            allUnscaled.Clear();
+            dirty = true; // the cached display lists have been disposed, they must be rebuilt if this ProjectedModel is connected again
             this.paintTo3D = null;
             Settings.GlobalSettings.SettingChangedEvent -= new SettingChangedDelegate(OnSettingChanged);
         }


### PR DESCRIPTION
## Summary
Fixed potential null reference exceptions in the `Disconnect` method of `ProjectedModel` by adding null-conditional operators when disposing display lists, and ensured proper cleanup by clearing collections and resetting the dirty flag.

## Key Changes
- Added null-conditional operators (`?.`) when disposing `IPaintTo3DList` objects in all four collection loops (`allCurves`, `allFaces`, `allTransparent`, `allUnscaled`) to safely handle null entries
- Added explicit `Clear()` calls on all four collections after disposal to remove references to disposed objects
- Set `dirty = true` flag to ensure display lists are rebuilt if the `ProjectedModel` is reconnected
- Added clarifying comment explaining that `IPaintTo3D.CloseList` can return null for empty display lists

## Implementation Details
The change addresses a robustness issue where display lists without content could be null, causing null reference exceptions during disconnection. The fix ensures safe disposal and proper state management for reconnection scenarios.

https://claude.ai/code/session_011oUmeFkaatDXuJvhxJAPCK