### PR TITLE
Fix undo/redo for multi-object operations on GeoObjectList

### DIFF
--- a/CADability/GeoObject.cs
+++ b/CADability/GeoObject.cs
@@ -770,6 +770,20 @@ namespace CADability.GeoObject
                 }
             }
             /// <summary>
+            /// Changing a GeoObject with a single <see cref="GeoObjectList"/> as the parameter for the undo
+            /// method, e.g. undoing <see cref="Block.Add(GeoObjectList)"/> by calling Remove with that list.
+            /// See the according constructor of <see cref="ReversibleChange"/> for why this overload is
+            /// required: without it the list would be spread into one parameter per contained object and
+            /// the undo would silently do nothing.
+            /// </summary>
+            /// <param name="geoObject">the GeoObject</param>
+            /// <param name="MethodOrPropertyName">name of a public method that might be called later by undo</param>
+            /// <param name="Parameter">the list to pass as a single parameter</param>
+            public Changing(IGeoObjectImpl geoObject, string MethodOrPropertyName, GeoObjectList Parameter)
+                : this(geoObject, MethodOrPropertyName, new object[] { Parameter })
+            {
+            }
+            /// <summary>
             /// Changing a GeoObject with a specification on how to undo that change.
             /// Undo might be performed later vie reflection. So we need the name of the method
             /// here and the parameters for that method. The method must be in the given interface.

--- a/CADability/GeoObjectChange.cs
+++ b/CADability/GeoObjectChange.cs
@@ -46,6 +46,17 @@ namespace CADability.GeoObject
 		{ }
 
 		/// <summary>
+		/// Creates a new GeoObjectChange with a single <see cref="GeoObjectList"/> parameter. See the
+		/// according constructor of <see cref="ReversibleChange"/> for why this overload is required.
+		/// </summary>
+		/// <param name="objectToChange">The object which will be or was changed</param>
+		/// <param name="methodOrPropertyName">the case sensitive name of the method or property</param>
+		/// <param name="parameter">the list to pass as a single parameter</param>
+		public GeoObjectChange(IGeoObject objectToChange, string methodOrPropertyName, GeoObjectList parameter)
+			: base(objectToChange, methodOrPropertyName, parameter)
+		{ }
+
+		/// <summary>
 		/// Creates a new GeoObjectChange object that reflects a modification by the <see cref="ModOp"/> m.
 		/// </summary>
 		/// <param name="objectToChange">The object which will be or was changed</param>

--- a/CADability/ReversibleChange.cs
+++ b/CADability/ReversibleChange.cs
@@ -1,3 +1,4 @@
+using CADability.GeoObject;
 using System;
 using System.Globalization;
 using System.Reflection;
@@ -67,6 +68,25 @@ namespace CADability
             this.parameter = parameter;
             this.parameters = null;
             this.interfaceForMethod = null;
+        }
+        /// <summary>
+        /// Creates a ReversibleChange with a single <see cref="GeoObjectList"/> parameter, e.g. to undo
+        /// <see cref="Model.Remove(GeoObjectList)"/> by calling <see cref="Model.Add(GeoObjectList)"/>.
+        /// <para>
+        /// This overload must exist: GeoObjectList defines an implicit conversion to IGeoObject[], which in
+        /// turn converts to object[] by array covariance. Without this overload a single GeoObjectList
+        /// argument binds to the "params object[]" constructor in its normal form, so the list is spread
+        /// into one parameter per contained object instead of being passed as one parameter. Undo would
+        /// then look for a method taking n objects, not find it and silently do nothing - which broke undo
+        /// for every operation on more than one object.
+        /// </para>
+        /// </summary>
+        /// <param name="objectToChange">The object which will be or was changed</param>
+        /// <param name="methodOrPropertyName">the case sensitive name of the method or property</param>
+        /// <param name="parameter">the list to pass as a single parameter</param>
+        public ReversibleChange(object objectToChange, string methodOrPropertyName, GeoObjectList parameter)
+            : this(objectToChange, methodOrPropertyName, (object)parameter)
+        {
         }
         /// <summary>
         /// The provided funtion knows how to undo the change and has the data, which is needed for the undo, captured
@@ -248,7 +268,8 @@ namespace CADability
         public object[] Parameters
         {
             get
-            {
+            {   // parameters is filled lazily in Undo(), so fall back to the single parameter constructor value
+                if (parameters == null) return new object[] { parameter };
                 return parameters.Clone() as object[];
             }
         }

--- a/CADability/UndoRedoSystem.cs
+++ b/CADability/UndoRedoSystem.cs
@@ -202,7 +202,12 @@ namespace CADability
             if (ToUndo is ReversibleChange)
             {
                 // System.Diagnostics.Debug.WriteLine("Simple Undo: " + (ToUndo as ReversibleChange).MethodOrPropertyName);
-                (ToUndo as ReversibleChange).Undo();
+                ReversibleChange reversibleChange = ToUndo as ReversibleChange;
+                if (!reversibleChange.Undo())
+                {   // ReversibleChange.Undo returns false when it cannot find a matching method or property.
+                    // Without this trace such a step is silently dropped and the user just sees an undo that does nothing.
+                    System.Diagnostics.Trace.WriteLine("UndoRedoSystem: undo step failed, no matching method or property: " + reversibleChange.ToString());
+                }
             }
             else
             {   // es muss eine ArrayList sein, also rückwärts iterieren

--- a/tests/CADability.Tests/UndoRedoTests.cs
+++ b/tests/CADability.Tests/UndoRedoTests.cs
@@ -1,0 +1,155 @@
+using CADability.GeoObject;
+
+namespace CADability.Tests
+{
+    /// <summary>
+    /// Regression tests for undoing operations that take a whole <see cref="GeoObjectList"/>.
+    /// GeoObjectList has an implicit conversion to IGeoObject[], which converts to object[] by array
+    /// covariance. A single GeoObjectList argument therefore binds to the "params object[]" constructor
+    /// of <see cref="ReversibleChange"/> and used to be spread into one parameter per contained object.
+    /// The undo then looked for a method taking n objects, did not find one and silently did nothing,
+    /// so deleting more than one object could not be undone.
+    /// </summary>
+    [TestClass]
+    public class UndoRedoTests
+    {
+        private static Line MakeLine(double x)
+        {
+            Line line = Line.Construct();
+            line.SetTwoPoints(new GeoPoint(x, 0, 0), new GeoPoint(x + 10, 5, 0));
+            return line;
+        }
+
+        private static Project MakeProject(int lineCount, out Model model)
+        {
+            Project project = Project.CreateSimpleProject();
+            model = project.GetActiveModel();
+            for (int i = 0; i < lineCount; i++) model.Add(MakeLine(i * 20));
+            project.Undo.Clear();
+            return project;
+        }
+
+        /// <summary>
+        /// Does what SelectObjectsAction does for the menu command "MenuId.Object.Delete".
+        /// </summary>
+        private static void DeleteFromModel(Project project, Model model, GeoObjectList selectedObjects)
+        {
+            using (project.Undo.UndoFrame)
+            {
+                GeoObjectList toRemoveFromModel = new GeoObjectList();
+                for (int i = 0; i < selectedObjects.Count; i++)
+                {
+                    if (selectedObjects[i].Owner == model) toRemoveFromModel.Add(selectedObjects[i]);
+                }
+                if (toRemoveFromModel.Count > 0) model.Remove(toRemoveFromModel);
+            }
+        }
+
+        [DataTestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(3)]
+        public void UndoOfDelete_RestoresAllDeletedObjects(int deleteCount)
+        {
+            Project project = MakeProject(5, out Model model);
+            GeoObjectList toDelete = new GeoObjectList();
+            for (int i = 0; i < deleteCount; i++) toDelete.Add(model[i]);
+
+            DeleteFromModel(project, model, toDelete);
+            Assert.AreEqual(5 - deleteCount, model.Count, "objects were not deleted");
+
+            Assert.IsTrue(project.Undo.UndoLastStep());
+            Assert.AreEqual(5, model.Count, "undo did not restore all deleted objects");
+        }
+
+        [DataTestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(3)]
+        public void RedoOfDelete_RemovesTheObjectsAgain(int deleteCount)
+        {
+            Project project = MakeProject(5, out Model model);
+            GeoObjectList toDelete = new GeoObjectList();
+            for (int i = 0; i < deleteCount; i++) toDelete.Add(model[i]);
+
+            DeleteFromModel(project, model, toDelete);
+            project.Undo.UndoLastStep();
+
+            Assert.IsTrue(project.Undo.RedoLastStep());
+            Assert.AreEqual(5 - deleteCount, model.Count, "redo did not remove the objects again");
+        }
+
+        [TestMethod]
+        public void UndoOfDelete_StillWorksAfterAPreviousUndo()
+        {
+            // the scenario as reported: delete a single line, undo it, then delete two lines and undo that
+            Project project = MakeProject(5, out Model model);
+
+            GeoObjectList first = new GeoObjectList();
+            first.Add(model[0]);
+            DeleteFromModel(project, model, first);
+            project.Undo.UndoLastStep();
+            Assert.AreEqual(5, model.Count);
+
+            GeoObjectList second = new GeoObjectList();
+            second.Add(model[0]);
+            second.Add(model[1]);
+            DeleteFromModel(project, model, second);
+            project.Undo.UndoLastStep();
+            Assert.AreEqual(5, model.Count, "undo of the second delete did not restore the objects");
+        }
+
+        [DataTestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(3)]
+        public void UndoOfModelAddList_RemovesAllAddedObjects(int addCount)
+        {
+            Project project = MakeProject(0, out Model model);
+            GeoObjectList toAdd = new GeoObjectList();
+            for (int i = 0; i < addCount; i++) toAdd.Add(MakeLine(i * 20));
+
+            model.Add(toAdd);
+            Assert.AreEqual(addCount, model.Count);
+
+            Assert.IsTrue(project.Undo.UndoLastStep());
+            Assert.AreEqual(0, model.Count, "undo did not remove all added objects");
+        }
+
+        [DataTestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(3)]
+        public void UndoOfBlockAddList_RemovesAllAddedObjects(int addCount)
+        {
+            Project project = MakeProject(0, out Model model);
+            Block block = Block.Construct();
+            model.Add(block);
+            project.Undo.Clear();
+
+            GeoObjectList toAdd = new GeoObjectList();
+            for (int i = 0; i < addCount; i++) toAdd.Add(MakeLine(i * 20));
+
+            block.Add(toAdd);
+            Assert.AreEqual(addCount, block.Count);
+
+            Assert.IsTrue(project.Undo.UndoLastStep());
+            Assert.AreEqual(0, block.Count, "undo did not remove all objects added to the block");
+        }
+
+        [TestMethod]
+        public void ReversibleChange_KeepsAGeoObjectListAsASingleParameter()
+        {
+            // the root cause: a GeoObjectList must not be spread into one parameter per contained object
+            Model model = new Model();
+            GeoObjectList list = new GeoObjectList();
+            list.Add(MakeLine(0));
+            list.Add(MakeLine(20));
+
+            ReversibleChange change = new ReversibleChange(model, "Add", list);
+
+            Assert.AreEqual(1, change.Parameters.Length, "the list was spread into several parameters");
+            Assert.AreSame(list, change.Parameters[0]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixed a critical bug where undo/redo operations failed silently for any operation involving multiple objects in a `GeoObjectList`. The issue was caused by implicit array conversion spreading the list into individual parameters instead of keeping it as a single parameter.

## Key Changes

- **Added specialized constructors for `GeoObjectList` parameters** across three classes:
  - `ReversibleChange`: New overload that accepts `GeoObjectList` as a single parameter instead of spreading it via `params object[]`
  - `GeoObjectChange`: Corresponding overload for consistency
  - `GeoObject.Changing`: Overload for the internal change tracking mechanism

- **Fixed `ReversibleChange.Parameters` property**: Added fallback logic to return the single parameter when `parameters` is null (lazy initialization case)

- **Improved error visibility in `UndoRedoSystem.Undo()`**: Added trace output when undo fails to find a matching method, preventing silent failures

- **Added comprehensive regression tests** in `UndoRedoTests.cs`:
  - Tests for undoing delete operations with 1-3 objects
  - Tests for redo operations
  - Tests for sequential undo operations
  - Tests for add operations on both `Model` and `Block`
  - Direct test of `ReversibleChange` parameter handling

## Implementation Details

The root cause was that `GeoObjectList` has an implicit conversion to `IGeoObject[]`, which converts to `object[]` via array covariance. This caused a single `GeoObjectList` argument to bind to the `params object[]` constructor and be spread into one parameter per contained object. The undo system would then fail to find a matching method signature and silently do nothing.

The fix introduces explicit overloads that accept `GeoObjectList` directly, ensuring it's treated as a single parameter. This allows operations like `Model.Remove(GeoObjectList)` to be properly undone by calling `Model.Add(GeoObjectList)` with the correct signature.

https://claude.ai/code/session_01CRu7LbrrntCj4jQX4X5ZmF